### PR TITLE
Use bash for npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,9 +88,11 @@ jobs:
           draft: false
       
       - name: Publish to npmjs.org
-        uses: ./.github/actions/platform-shell
-        with:
-          run: pnpm -F "{packages/impl}" run publish --provenance
+        shell: bash
+        working-directory: packages/impl
+        run: |
+          npm install -g npm@latest
+          npm publish package.tar.gz --access public --provenance
       
       - name: Verify release installation
         shell: bash

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "husky": "catalog:"
   },
   "scripts": {
-    "preinstall:cargo": "cargo binstall cargo-binstall cargo-run-bin -y && cargo bin --install",
-    "preinstall:npm": "npm install -g npm@latest",
-    "preinstall": "pnpm run preinstall:cargo && pnpm run preinstall:npm",
+    "preinstall": "cargo binstall cargo-binstall cargo-run-bin -y && cargo bin --install",
     "postinstall": "node scripts/setup-path.ts && pnpm exec playwright install-deps",
     "rustup:update": "rustup update",
     "rustup:install": "rustup toolchain install nightly --profile minimal --component clippy --component rustfmt",

--- a/packages/impl/package.json
+++ b/packages/impl/package.json
@@ -89,7 +89,6 @@
     "dev-test:rust": "pnpm run test:nextest && pnpm run test:rustdoc",
     "dev-test": "pnpm run dev-test:ts && pnpm run dev-test:rust",
     "pack-addon": "pnpm exec node-pre-gyp package",
-    "publish": "npm publish package.tar.gz --access public",
     "install:skip": "node -p \"process.exit(+!(require('./package.json').version === '0.0.0'))\"",
     "install": "node-pre-gyp install --update-binary --fallback-to-build=false || pnpm run install:skip"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified release workflow to run the publish step via a direct shell command for more predictable execution.
  * Consolidated install scripts into a single cargo-based preinstall for a streamlined setup.
  * Removed the package-level publish script to centralize publishing in the workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->