### PR TITLE
Clean up Renovate config and fix smoke test rate limits (#120)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,19 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":separateMajorReleases",
-    ":combinePatchMinorReleases",
-    "helpers:pinGitHubActionDigests"
-  ],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "timezone": "UTC",
   "schedule": ["every weekend"],
   "minimumReleaseAge": "7 days",
   "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": false
-    },
     {
       "description": "Ignore major updates for node and python in mise.toml",
       "matchManagers": ["mise"],

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,8 @@ jobs:
   smoke-test:
     name: "Smoke test"
     timeout-minutes: 10
-    permissions: {}
+    permissions:
+      contents: "read" # GITHUB_TOKEN for slsa postinstall
     needs:
       - "init"
       - "publish"
@@ -200,6 +201,8 @@ jobs:
           exit 1
       - name: "Smoke test"
         shell: "bash"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           cd "$(mktemp -d)"
           npm init -y


### PR DESCRIPTION
Remove redundant Renovate presets already included in config:recommended and no-op automerge rule. Fix smoke test GitHub API rate limit failures by providing GITHUB_TOKEN to the slsa postinstall step.