### PR TITLE
Make undici a peer dependency and document immutable releases

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -9,14 +9,14 @@ Electron.
 
 ## Why node-reqwest?
 
-| Feature | node-reqwest | Node.js / undici |
-| --- | --- | --- |
-| DNS resolver | Recursive ([hickory-dns][hickory]) | Non-recursive (c-ares) — crashes Electron on Windows for nonexistent domains |
-| System CA certificates | Built-in | Requires [win-ca][win-ca], [mac-ca][mac-ca] |
-| System proxy | Built-in | Not available (complex Electron [workaround][electron-proxy]) |
-| SOCKS proxy | Built-in | Not available |
-| HTTP/2 | Full support via [hyper][hyper] | Limited |
-| TLS | [rustls][rustls] | OpenSSL |
+| Feature                | node-reqwest                       | Node.js / undici                                                             |
+| ---------------------- | ---------------------------------- | ---------------------------------------------------------------------------- |
+| DNS resolver           | Recursive ([hickory-dns][hickory]) | Non-recursive (c-ares) — crashes Electron on Windows for nonexistent domains |
+| System CA certificates | Built-in                           | Requires [win-ca][win-ca], [mac-ca][mac-ca]                                  |
+| System proxy           | Built-in                           | Not available (complex Electron [workaround][electron-proxy])                |
+| SOCKS proxy            | Built-in                           | Not available                                                                |
+| HTTP/2                 | Full support via [hyper][hyper]    | Limited                                                                      |
+| TLS                    | [rustls][rustls]                   | OpenSSL                                                                      |
 
 [hickory]: https://github.com/hickory-dns/hickory-dns
 [win-ca]: https://www.npmjs.com/package/win-ca
@@ -36,8 +36,8 @@ import { Agent } from "node-reqwest";
 import { setGlobalDispatcher } from "undici";
 
 const agent = new Agent({
-  allowH2: true,
-  proxy: "system",
+    allowH2: true,
+    proxy: "system",
 });
 
 setGlobalDispatcher(agent);
@@ -49,7 +49,12 @@ const response = await fetch("https://example.com");
 ## Installation safety
 
 This package downloads a precompiled binary during `npm install`.
-The [postinstall script][postinstall] uses
+GitHub releases for this project are
+[immutable][gh-immutable-releases] — once published, release
+assets cannot be modified or replaced, ensuring that the binary
+you download is the same one that was originally published.
+
+In addition, the postinstall script uses
 [node-addon-slsa][slsa] to cryptographically verify that the
 binary was built in the same GitHub Actions workflow run as this
 npm package, using [sigstore][sigstore] provenance attestations
@@ -57,7 +62,7 @@ and the [GitHub Attestations API][gh-attestations].
 
 Installation aborts with a `SECURITY` error if any check fails.
 
-[postinstall]: https://github.com/vadimpiven/node_reqwest/blob/main/packages/node/scripts/postinstall.js
+[gh-immutable-releases]: https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases
 [slsa]: https://www.npmjs.com/package/node-addon-slsa
 [sigstore]: https://www.sigstore.dev/
 [gh-attestations]: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,8 +69,7 @@
     "postinstall": "slsa wget"
   },
   "dependencies": {
-    "node-addon-slsa": "0.6.0",
-    "undici": "catalog:"
+    "node-addon-slsa": "0.6.0"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "catalog:",
@@ -80,9 +79,13 @@
     "electron": "catalog:",
     "monocart-reporter": "catalog:",
     "typescript": "catalog:",
+    "undici": "catalog:",
     "vite": "catalog:",
     "vite-plugin-dts": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "undici": ">=7.0.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       node-addon-slsa:
         specifier: 0.6.0
         version: 0.6.0
-      undici:
-        specifier: 'catalog:'
-        version: 7.22.0
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -130,6 +127,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.1-rc
+      undici:
+        specifier: 'catalog:'
+        version: 7.22.0
       vite:
         specifier: 'catalog:'
         version: 8.0.0-beta.16(@types/node@24.12.0)(esbuild@0.27.3)(yaml@2.8.2)


### PR DESCRIPTION
Move undici from dependencies to peerDependencies (>=7.0.0) to avoid instanceof failures when consumers use their own undici copy with setGlobalDispatcher. Add immutable GitHub releases mention to the installation safety section of the README.