### PR TITLE
Bump node-addon-slsa to v0.8.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@e9dda1e232a026d46ffd53ceff631f521709345c" # v0.8.2
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@47d59866f367ca19395d53c313ff9fc9fc8a30c6" # v0.8.3
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages


### PR DESCRIPTION
## Summary
- Bumps the `publish.yaml` reusable workflow pin from v0.8.2 → v0.8.3 (commit 47d5986).
- v0.8.3 fixes the self-location bug (vadimpiven/node-addon-slsa#37): `github.workflow_ref`/`workflow_sha` resolve to the caller in `workflow_call`, which broke the old self-checkout. v0.8.3 references composite actions via cross-repo `uses:` instead.

## Test plan
- [ ] Merge + tag v0.0.21 to exercise the Publish job end-to-end.
- [ ] Confirm the Publish job reaches `Attest addons` (previously failed before that step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)