### PR TITLE
Bump node-addon-slsa to v0.8.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@47d59866f367ca19395d53c313ff9fc9fc8a30c6" # v0.8.3
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@576d34885bf6205914edaa6fc66cb4024694fbdb" # v0.8.4
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages


### PR DESCRIPTION
## Summary
- Pins `publish.yaml` to v0.8.4 (commit 576d348).
- v0.8.4 drops the `npm install -g npm@latest` self-upgrade and switches to Node 24, whose bundled npm already satisfies trusted-publishing ≥ 11.5.1. Fixes the `Cannot find module 'promise-retry'` failure from v0.0.21.

## Test plan
- [ ] Merge + tag v0.0.22.
- [ ] Confirm the Publish job reaches `npm publish` without the arborist crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)