### PR TITLE
Bump node-addon-slsa to v0.8.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@576d34885bf6205914edaa6fc66cb4024694fbdb" # v0.8.4
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@a72147edebbb3c7d7631fd23c66a3258b502054b" # v0.8.5
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages


### PR DESCRIPTION
## Summary
- Pins \`publish.yaml\` to v0.8.5 (commit a72147e).
- v0.8.5 sha-pins the intra-repo action refs that v0.8.4 had set to \`@v0.8.4\` tag refs. GHA org policy enforces sha-pinning at runtime (not just zizmor), so v0.0.22's Publish job failed on action resolution before executing any step.

## Test plan
- [ ] Merge + tag v0.0.23.
- [ ] Publish job should reach \`npm publish\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)