### PR TITLE
Bump node-addon-slsa to v0.8.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@a72147edebbb3c7d7631fd23c66a3258b502054b" # v0.8.5
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@2cfbe734c1c136daacd53be6f798fac00f6ed203" # v0.8.6
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages


### PR DESCRIPTION
## Summary
- Pins \`publish.yaml\` to v0.8.6 (commit 2cfbe73).
- v0.8.6 fixes \`fetchWithRetry\`: follows 3xx redirects with RFC 9110 semantics (strip Authorization cross-origin, rewrite 301/302/303 non-GET → GET, refuse https→http downgrades, per-hop stall timers). v0.0.23 Publish failed with \`SECURITY: Addon provenance verification failed\` because every addon hashed to SHA-256 of the empty string — the GitHub release-asset 302 body was being hashed instead of the CDN-served payload.

## Test plan
- [ ] Merge + tag v0.0.24.
- [ ] Confirm Publish reaches \`npm publish\` and the new release is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)