### PR TITLE
Bump node-addon-slsa to v0.8.7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@2cfbe734c1c136daacd53be6f798fac00f6ed203" # v0.8.6
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@f4c8ca2c64c01dfe67773f7beaa31bb2c51a8c23" # v0.8.7
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages


### PR DESCRIPTION
## Summary
- Pins \`publish.yaml\` to v0.8.7 (commit f4c8ca2).
- v0.8.7 moves publish.yaml's intra-repo action pins to v0.8.6's sha — that's where the redirect-fix bytes live. v0.8.6 itself still pointed at v0.8.3's (broken) action code, so v0.0.24's Publish still hashed the empty 302 body.

## Test plan
- [ ] Merge + tag v0.0.25.
- [ ] Confirm Publish hashes real addon bytes (not \`e3b0c44...\`) and reaches \`npm publish\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)