### PR TITLE
Bump node-addon-slsa to v0.8.10

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@f4c8ca2c64c01dfe67773f7beaa31bb2c51a8c23" # v0.8.7
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@6e425ee25b2589fea4b46ff3bfa7f6462b668066" # v0.8.10
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages


### PR DESCRIPTION
## Summary
- Pins `publish.yaml` to v0.8.10 (commit 6e425ee).
- Activates the typed-IO-boundary refactor (vadimpiven/node-addon-slsa#43) landed via #44 + oxfmt fix in #45. HttpClient + RekorClient with closed error unions, one `withRetry` HOF, pipeline + reducer with tamper-signal short-circuit.

## Test plan
- [ ] Merge + tag v0.0.26.
- [ ] Confirm Publish job's Rekor flow completes cleanly (one TUF fetch per handle; distinct error shapes per failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)