### PR TITLE
Bump node-addon-slsa to v0.8.12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # sigstore OIDC + npm trusted publishing
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@6e425ee25b2589fea4b46ff3bfa7f6462b668066" # v0.8.10
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@29bbe43259d77f4bf05eb1971483a337e1320114" # v0.8.12
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,7 +69,7 @@
     "postinstall": "slsa wget"
   },
   "dependencies": {
-    "node-addon-slsa": "0.8.2"
+    "node-addon-slsa": "0.8.12"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
   packages/node:
     dependencies:
       node-addon-slsa:
-        specifier: 0.8.2
-        version: 0.8.2
+        specifier: 0.8.12
+        version: 0.8.12
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-slsa@0.8.2:
-    resolution: {integrity: sha512-PiRCletWXq/BXc0kO2c+wSAQLwYZ/M+5yuZRJFsudVjs+oQs2hrp3Dzp8Ut7xEFZKxFzgyTEOSA6MgBlmem07Q==}
+  node-addon-slsa@0.8.12:
+    resolution: {integrity: sha512-bivDNtAxAi5WOGKIIPgeu4bKWg3lHMrZWvlc1dBVPZHy/aItzWx/mDzS0B66+hGAWAwGf7aE3F7L2ucobEx7IQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -4699,7 +4699,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-addon-slsa@0.8.2: {}
+  node-addon-slsa@0.8.12: {}
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
Picks up the redirect-interceptor fix
(vadimpiven/node-addon-slsa#46, activated by #47): the verify-addons action was silently dropping GitHub release 302→CDN redirects when passed `getGlobalDispatcher()`, hashing zero bytes, and failing Rekor lookup with `e3b0c44…b855` (SHA-256 of empty).

- `.github/workflows/release.yaml`: publish.yaml pin v0.8.10 → v0.8.12
- `packages/node/package.json`: node-addon-slsa 0.8.2 → 0.8.12
- `pnpm-lock.yaml`: regenerated