### PR TITLE
chore(deps): bump node-addon-slsa to 0.9.1

### DIFF
--- a/.github/actions/init-workflow/action.yaml
+++ b/.github/actions/init-workflow/action.yaml
@@ -46,6 +46,42 @@ outputs:
   mise-version:
     description: "Mise version"
     value: "${{ steps.parse.outputs.mise-version }}"
+  addons:
+    description: >-
+      JSON map of native addon URLs and sidecar bundle URLs for the current release tag, consumed by node-addon-slsa's `attest-addons` action and reusable `publish.yaml` workflow.
+    value: |
+      {
+        "linux": {
+          "x64": {
+            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-x64.node.gz",
+            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-x64.node.gz.sigstore"
+          },
+          "arm64": {
+            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-arm64.node.gz",
+            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-arm64.node.gz.sigstore"
+          }
+        },
+        "darwin": {
+          "x64": {
+            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-x64.node.gz",
+            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-x64.node.gz.sigstore"
+          },
+          "arm64": {
+            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-arm64.node.gz",
+            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-arm64.node.gz.sigstore"
+          }
+        },
+        "win32": {
+          "x64": {
+            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-x64.node.gz",
+            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-x64.node.gz.sigstore"
+          },
+          "arm64": {
+            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-arm64.node.gz",
+            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-arm64.node.gz.sigstore"
+          }
+        }
+      }
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
       docker-cache: "${{ steps.init-workflow.outputs.docker-cache }}"
       docker-service: "${{ steps.init-workflow.outputs.docker-service }}"
       mise-version: "${{ steps.init-workflow.outputs.mise-version }}"
+      addons: "${{ steps.init-workflow.outputs.addons }}"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
@@ -52,8 +53,6 @@ jobs:
     permissions:
       contents: "write" # to upload release assets
       packages: "write" # to push Docker images
-      id-token: "write" # for OIDC authentication
-      attestations: "write" # for build provenance
     needs:
       - "init"
     strategy:
@@ -93,15 +92,41 @@ jobs:
         with:
           docker-service: "${{ needs.init.outputs.docker-service }}"
           run: 'pnpm -F "{packages/node}" run pack-addon'
-      - name: "Attest build provenance"
-        uses: "actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32" # v4.1.0
-        with:
-          subject-path: "packages/node/dist/*.gz"
       - name: "Upload node addon"
         shell: "bash"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: 'gh release upload "$GITHUB_REF_NAME" packages/node/dist/*.gz'
+  attest-addons:
+    name: "Attest addons (sigstore)"
+    needs:
+      - "init"
+      - "build-addon"
+    if: "needs.build-addon.result == 'success'"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 15
+    permissions:
+      id-token: "write" # sigstore OIDC
+      attestations: "write" # @actions/attest writes to the GitHub Attestations API
+      contents: "write" # upload sidecar bundles to the draft release
+    steps:
+      - name: "Attest addons (public-good sigstore)"
+        id: "attest"
+        # File name must match `addon.attestWorkflow` in package.json — the
+        # install-time verifier pins attestations to this exact workflow.
+        uses: "vadimpiven/node-addon-slsa/.github/actions/attest-addons@d2e5e5635f1a11a4b283ca47ed316921dec3e416" # v0.11.1
+        with:
+          addons: "${{ needs.init.outputs.addons }}"
+          bundle-dir: "${{ runner.temp }}/slsa-bundles"
+      - name: "Upload sidecar bundles to draft release"
+        shell: "bash"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          BUNDLES: "${{ steps.attest.outputs.bundles }}"
+        run: |
+          set -euo pipefail
+          mapfile -t paths < <(jq -r '.[].path' <<<"$BUNDLES")
+          gh release upload "$GITHUB_REF_NAME" "${paths[@]}" --clobber
   build-packages:
     name: "Build packages"
     timeout-minutes: 30
@@ -161,32 +186,18 @@ jobs:
   publish:
     name: "Publish"
     needs:
-      - "build-addon"
+      - "init"
+      - "attest-addons"
       - "build-packages"
-    if: "needs.build-packages.result == 'success'"
+    if: "needs.attest-addons.result == 'success' && needs.build-packages.result == 'success'"
     permissions:
       contents: "read" # to fetch reusable workflow repo
-      id-token: "write" # sigstore OIDC + npm trusted publishing
-      attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@29bbe43259d77f4bf05eb1971483a337e1320114" # v0.8.12
+      id-token: "write" # npm trusted publishing
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@d2e5e5635f1a11a4b283ca47ed316921dec3e416" # v0.11.1
     with:
       access: "public"
       tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages
-      addons: |
-        {
-          "linux":  {
-            "x64":   "https://github.com/vadimpiven/node_reqwest/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-x64.node.gz",
-            "arm64": "https://github.com/vadimpiven/node_reqwest/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-arm64.node.gz"
-          },
-          "darwin": {
-            "x64":   "https://github.com/vadimpiven/node_reqwest/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-x64.node.gz",
-            "arm64": "https://github.com/vadimpiven/node_reqwest/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-arm64.node.gz"
-          },
-          "win32":  {
-            "x64":   "https://github.com/vadimpiven/node_reqwest/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-x64.node.gz",
-            "arm64": "https://github.com/vadimpiven/node_reqwest/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-arm64.node.gz"
-          }
-        }
+      addons: "${{ needs.init.outputs.addons }}"
   docs:
     name: "Deploy docs"
     needs: "publish"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,9 +1800,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,7 +69,7 @@
     "postinstall": "slsa wget"
   },
   "dependencies": {
-    "node-addon-slsa": "0.8.12"
+    "node-addon-slsa": "0.11.1"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "catalog:",
@@ -94,6 +94,7 @@
   },
   "addon": {
     "path": "./dist/node_reqwest.node",
-    "url": "https://github.com/vadimpiven/node_reqwest/releases/download/v{version}/node_reqwest-v{version}-{platform}-{arch}.node.gz"
+    "manifest": "./dist/slsa-manifest.json",
+    "attestWorkflow": "release.yaml"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
   packages/node:
     dependencies:
       node-addon-slsa:
-        specifier: 0.8.12
-        version: 0.8.12
+        specifier: 0.11.1
+        version: 0.11.1
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-slsa@0.8.12:
-    resolution: {integrity: sha512-bivDNtAxAi5WOGKIIPgeu4bKWg3lHMrZWvlc1dBVPZHy/aItzWx/mDzS0B66+hGAWAwGf7aE3F7L2ucobEx7IQ==}
+  node-addon-slsa@0.11.1:
+    resolution: {integrity: sha512-tScYKhJ+MgHBpP9IAASkX9glpOM7kMcIKGfWVC/jjMk9Ny0+M7D/mhh304DthpxGpk+TsMxLfIZG+DHK9mu/WA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -4699,7 +4699,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-addon-slsa@0.8.12: {}
+  node-addon-slsa@0.11.1: {}
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
- packages/node: dependency 0.8.12 → 0.9.1.
- packages/node: remove addon.url — the published manifest now drives downloads; see node-addon-slsa v0.9.0 breaking changes.
- release.yaml: bump reusable-workflow pin to v0.9.1 (000ddac). Rewrite the addons: input to the new {url, bundleUrl} leaf shape; bundleUrl points at the sidecar sigstore bundle co-located with each binary.