### PR TITLE
fix(release): flip release out of draft only after attest-addons

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,19 +178,32 @@ jobs:
         uses: "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9" # v5.0.0
         with:
           path: "packages/node/docs"
-      - name: "Upload package and publish release"
+      - name: "Upload pre-packed tarball to draft release"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        run: |
-          gh release upload "$GITHUB_REF_NAME" packages/node/package.tar.gz
-          gh release edit "$GITHUB_REF_NAME" --draft=false
+        run: 'gh release upload "$GITHUB_REF_NAME" packages/node/package.tar.gz'
+  finalize-release:
+    name: "Finalize release"
+    needs:
+      - "attest-addons"
+      - "build-packages"
+    if: "needs.attest-addons.result == 'success' && needs.build-packages.result == 'success'"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 5
+    permissions:
+      contents: "write" # flip release out of draft
+    steps:
+      - name: "Flip release out of draft"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+        run: 'gh release edit "$GITHUB_REF_NAME" --draft=false'
   publish:
     name: "Publish"
     needs:
       - "init"
-      - "attest-addons"
-      - "build-packages"
-    if: "needs.attest-addons.result == 'success' && needs.build-packages.result == 'success'"
+      - "finalize-release"
+    if: "needs.finalize-release.result == 'success'"
     permissions:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # npm trusted publishing


### PR DESCRIPTION
## Summary
- `build-packages` flipped the release out of draft (`gh release edit --draft=false`) while running in parallel with `attest-addons`. When `build-packages` finished first, the release became immutable and the sigstore sidecar upload failed with `HTTP 422: Cannot upload assets to an immutable release` — this is what broke the v0.0.29 release ([run](https://github.com/vadimpiven/node_reqwest/actions/runs/24935324881/job/73020326712)).
- Move the draft flip into a new `finalize-release` job that waits on both `attest-addons` and `build-packages`. `publish` now `needs: finalize-release` (transitively covering both upstream jobs).
- Wall-time is preserved: `attest-addons` and `build-packages` still run in parallel; only the single `gh release edit` call is serialised.

New job graph:
```
init → build-addon ─┬─→ attest-addons ─┐
                    │                  ├─→ finalize-release → publish → docs / smoke-test
                    └─→ build-packages ┘
```

## Test plan
- [ ] Cut a new tag (v0.0.30) and verify the release pipeline completes end-to-end, including npm publish and smoke test.
- [ ] Confirm the GitHub release for v0.0.30 contains all 6 `*.node.gz` binaries, all 6 `*.node.gz.sigstore` sidecars, and `package.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)