### PR TITLE
feat(release)!: per-binary attestation via node-addon-slsa v0.12.1

### DIFF
--- a/.github/actions/init-workflow/action.yaml
+++ b/.github/actions/init-workflow/action.yaml
@@ -46,42 +46,12 @@ outputs:
   mise-version:
     description: "Mise version"
     value: "${{ steps.parse.outputs.mise-version }}"
-  addons:
+  release-base-url:
     description: >-
-      JSON map of native addon URLs and sidecar bundle URLs for the current release tag, consumed by node-addon-slsa's `attest-addons` action and reusable `publish.yaml` workflow.
-    value: |
-      {
-        "linux": {
-          "x64": {
-            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-x64.node.gz",
-            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-x64.node.gz.sigstore"
-          },
-          "arm64": {
-            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-arm64.node.gz",
-            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-linux-arm64.node.gz.sigstore"
-          }
-        },
-        "darwin": {
-          "x64": {
-            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-x64.node.gz",
-            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-x64.node.gz.sigstore"
-          },
-          "arm64": {
-            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-arm64.node.gz",
-            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-darwin-arm64.node.gz.sigstore"
-          }
-        },
-        "win32": {
-          "x64": {
-            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-x64.node.gz",
-            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-x64.node.gz.sigstore"
-          },
-          "arm64": {
-            "url":       "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-arm64.node.gz",
-            "bundleUrl": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/node_reqwest-${{ github.ref_name }}-win32-arm64.node.gz.sigstore"
-          }
-        }
-      }
+      Public URL prefix where every `.node.gz` and `.node.gz.sigstore` for this
+      release tag will be served.
+    value: "https://github.com/${{ github.repository }}/releases/download/${{
+      github.ref_name }}/"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/init-workflow/action.yaml
+++ b/.github/actions/init-workflow/action.yaml
@@ -50,8 +50,7 @@ outputs:
     description: >-
       Public URL prefix where every `.node.gz` and `.node.gz.sigstore` for this
       release tag will be served.
-    value: "https://github.com/${{ github.repository }}/releases/download/${{
-      github.ref_name }}/"
+    value: "${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}/"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       docker-cache: "${{ steps.init-workflow.outputs.docker-cache }}"
       docker-service: "${{ steps.init-workflow.outputs.docker-service }}"
       mise-version: "${{ steps.init-workflow.outputs.mise-version }}"
-      addons: "${{ steps.init-workflow.outputs.addons }}"
+      release-base-url: "${{ steps.init-workflow.outputs.release-base-url }}"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
@@ -53,6 +53,8 @@ jobs:
     permissions:
       contents: "write" # to upload release assets
       packages: "write" # to push Docker images
+      id-token: "write" # sigstore OIDC for per-binary attestation
+      attestations: "write" # @actions/attest writes to the GitHub Attestations API
     needs:
       - "init"
     strategy:
@@ -92,42 +94,22 @@ jobs:
         with:
           docker-service: "${{ needs.init.outputs.docker-service }}"
           run: 'pnpm -F "{packages/node}" run pack-addon'
-      - name: "Upload node addon"
-        shell: "bash"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        run: 'gh release upload "$GITHUB_REF_NAME" packages/node/dist/*.gz'
-  attest-addons:
-    name: "Attest addons (sigstore)"
-    needs:
-      - "init"
-      - "build-addon"
-    if: "needs.build-addon.result == 'success'"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 15
-    permissions:
-      id-token: "write" # sigstore OIDC
-      attestations: "write" # @actions/attest writes to the GitHub Attestations API
-      contents: "write" # upload sidecar bundles to the draft release
-    steps:
-      - name: "Attest addons (public-good sigstore)"
+      - name: "Attest addon (public-good sigstore)"
         id: "attest"
         # File name must match `addon.attestWorkflow` in package.json — the
         # install-time verifier pins attestations to this exact workflow.
-        uses: "vadimpiven/node-addon-slsa/.github/actions/attest-addons@61100a0963f4fc8ffc8bcd3c2ea7a98cb2959439" # v0.11.2
+        uses: "vadimpiven/node-addon-slsa/.github/actions/attest-addon@fcd88c6850e28a2c526e747c108a00e6a9341634" # v0.12.1
         with:
-          addons: "${{ needs.init.outputs.addons }}"
-          bundle-dir: "${{ runner.temp }}/slsa-bundles"
-      - name: "Upload sidecar bundles to draft release"
+          binary: "packages/node/dist/*.node.gz"
+          url-prefix: "${{ needs.init.outputs.release-base-url }}"
+      - name: "Upload addon and sidecar to draft release"
         shell: "bash"
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          GH_REPO: "${{ github.repository }}" # this job has no checkout, so gh can't infer the repo
-          BUNDLES: "${{ steps.attest.outputs.bundles }}"
-        run: |
-          set -euo pipefail
-          mapfile -t paths < <(jq -r '.[].path' <<<"$BUNDLES")
-          gh release upload "$GITHUB_REF_NAME" "${paths[@]}" --clobber
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          BINARY_PATH: "${{ steps.attest.outputs.binary-path }}"
+          BUNDLE_PATH: "${{ steps.attest.outputs.bundle-path }}"
+        # `--clobber` so re-runs of a failed matrix cell don't 422 on partial uploads.
+        run: 'gh release upload "$GITHUB_REF_NAME" --clobber "$BINARY_PATH" "$BUNDLE_PATH"'
   build-packages:
     name: "Build packages"
     timeout-minutes: 30
@@ -182,12 +164,15 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: 'gh release upload "$GITHUB_REF_NAME" packages/node/package.tar.gz'
+  # Release becomes immutable here. On `publish` failure, re-run only
+  # the publish job — public URLs are stable, artifacts persist, and
+  # `publish.yaml` is idempotent (npm rejects duplicate-version publishes).
   finalize-release:
     name: "Finalize release"
     needs:
-      - "attest-addons"
+      - "build-addon"
       - "build-packages"
-    if: "needs.attest-addons.result == 'success' && needs.build-packages.result == 'success'"
+    if: "needs.build-addon.result == 'success' && needs.build-packages.result == 'success'"
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     permissions:
@@ -207,11 +192,12 @@ jobs:
     permissions:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # npm trusted publishing
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@61100a0963f4fc8ffc8bcd3c2ea7a98cb2959439" # v0.11.2
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@fcd88c6850e28a2c526e747c108a00e6a9341634" # v0.12.1
     with:
       access: "public"
-      tarball-artifact: "slsa-tarball" # must match `upload-artifact` name in build-packages
-      addons: "${{ needs.init.outputs.addons }}"
+      tarball-artifact: "slsa-tarball"
+      addons-artifact-pattern: "slsa-addons-*"
+      release-base-url: "${{ needs.init.outputs.release-base-url }}"
   docs:
     name: "Deploy docs"
     needs: "publish"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,7 +69,7 @@
     "postinstall": "slsa wget"
   },
   "dependencies": {
-    "node-addon-slsa": "0.11.1"
+    "node-addon-slsa": "0.12.1"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
   packages/node:
     dependencies:
       node-addon-slsa:
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.12.1
+        version: 0.12.1
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-slsa@0.11.1:
-    resolution: {integrity: sha512-tScYKhJ+MgHBpP9IAASkX9glpOM7kMcIKGfWVC/jjMk9Ny0+M7D/mhh304DthpxGpk+TsMxLfIZG+DHK9mu/WA==}
+  node-addon-slsa@0.12.1:
+    resolution: {integrity: sha512-sVqk0c/Res4R5thXDbuFKHhOcFNokuXaf51wZQXprmS6td2X0wZU/bGHmmnZH4sGyXGzlIVDdk5ws5g0DK2ASw==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -4699,7 +4699,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-addon-slsa@0.11.1: {}
+  node-addon-slsa@0.12.1: {}
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
## Summary

Adopt the descriptor-based attestation flow shipped in [vadimpiven/node-addon-slsa#58](https://github.com/vadimpiven/node-addon-slsa/pull/58) (v0.12.1):

- Each `build-addon` matrix cell calls `attest-addon` once. The action discovers the platform/arch from `process.platform`/`process.arch`, hashes the local `.node.gz`, mints a single-subject sigstore bundle, writes the sidecar, and uploads a per-binary descriptor as GHA artifact `slsa-addons-<platform>-<arch>`.
- The standalone `attest-addons` job is gone.
- `init-workflow` no longer outputs the 12-URL `addons` JSON blob — replaced by a single `release-base-url` string.
- `publish.yaml` invocation drops `addons:` in favor of `addons-artifact-pattern: slsa-addons-*` and `release-base-url:`.

Net **-39 lines**; one whole job removed.

## Why

The prior design re-fetched binaries from public release URLs during attest, which 404s on draft releases — that's why v0.0.30 failed: https://github.com/vadimpiven/node_reqwest/actions/runs/24937179522.

Per-cell attest signs the bytes the cell just produced. Public URLs are touched only at publish time (where the trust anchor is enforced) and at install time (where the embedded SLSA manifest is reverified).

## Operational note (added inline above `finalize-release`)

Once `finalize-release` flips the release out of draft, the GitHub release is immutable (immutable-releases is enabled on this repo). On `publish` failure, re-run only the failed `publish` job from the Actions UI — public URLs are stable, GHA artifacts persist, and `publish.yaml` is idempotent (npm rejects duplicate-version publishes). Do NOT attempt to modify or delete the release.

## Test plan

- [ ] Bump version, push tag `v0.0.30`, observe new release flow runs end-to-end (build-addon → finalize → publish → smoke).
- [ ] Verify `slsa wget` postinstall succeeds in the smoke-test job (downloads + verifies the sidecar against the embedded manifest).
- [ ] Confirm npm publishes `node-reqwest@0.0.30` with the SLSA manifest embedded in the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)