### PR TITLE
chore(deps): bump node-addon-slsa to v0.13.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
       contents: "write" # to upload binary + bundle to the draft release
       id-token: "write" # sigstore OIDC for per-binary attestation
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/attest-addon.yaml@f74796e76734df71e6a2298b7ef5097419595760" # v0.13.1
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/attest-addon.yaml@05d945b477a6476c12ae4b96cb42d5fbda0748d1" # v0.13.3
     with:
       binary-artifact: "addon-${{ matrix.platform }}-${{ matrix.arch }}"
       platform: "${{ matrix.platform }}"
@@ -198,7 +198,7 @@ jobs:
     permissions:
       contents: "read" # to fetch reusable workflow repo
       id-token: "write" # npm trusted publishing
-    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@f74796e76734df71e6a2298b7ef5097419595760" # v0.13.1
+    uses: "vadimpiven/node-addon-slsa/.github/workflows/publish.yaml@05d945b477a6476c12ae4b96cb42d5fbda0748d1" # v0.13.3
   docs:
     name: "Deploy docs"
     # Gated on publish so docs don't deploy for a release that didn't reach npm.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,7 +69,7 @@
     "postinstall": "slsa wget"
   },
   "dependencies": {
-    "node-addon-slsa": "0.13.1"
+    "node-addon-slsa": "0.13.3"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
   packages/node:
     dependencies:
       node-addon-slsa:
-        specifier: 0.13.1
-        version: 0.13.1
+        specifier: 0.13.3
+        version: 0.13.3
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-slsa@0.13.1:
-    resolution: {integrity: sha512-GFa7wD1dBHfC8T38cqO80KougjDdQHwurHMPIgy1kDBn5s4qzhT8M1Iwd9R9OfUaQijhxqMTVHUi2ZT7Nsgm/A==}
+  node-addon-slsa@0.13.3:
+    resolution: {integrity: sha512-JeF6iFh8B11hrtlqbNJDo/qycBe8MGD59bInf1anjpzUve98m60sxWQdAWrCRcq3mW+aiSqyK9KBu7Sdm6D30Q==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -4699,7 +4699,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-addon-slsa@0.13.1: {}
+  node-addon-slsa@0.13.3: {}
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
## Summary
- Bump `node-addon-slsa` CLI dep `0.13.1 → 0.13.3` and refresh `pnpm-lock.yaml`.
- Repin both reusable-workflow refs in `release.yaml` (`attest-addon.yaml`, `publish.yaml`) to commit `05d945b4…` — that's the v0.13.3 commit on `vadimpiven/node-addon-slsa@main`.

The headline fix in v0.13.2/v0.13.3 is the toolkit-checkout SHA inside the reusable workflows: `github.workflow_sha` returns the *caller's* SHA in a callee context, so the toolkit's local-path actions failed to resolve. Replaced with `job.workflow_sha` which correctly returns the callee's own SHA. Without this, the per-binary attestation job in `release.yaml` fails at `actions/checkout` with `not our ref`.

## Test plan
- [x] `pnpm install` resolves cleanly
- [x] `mise run check`
- [ ] Tag a release on this branch's merge commit; confirm `attest-addon` matrix and `publish` job both succeed