### PR TITLE
fix(release): include platform + arch in build matrix

### DIFF
--- a/.github/actions/init-workflow/action.yaml
+++ b/.github/actions/init-workflow/action.yaml
@@ -5,13 +5,13 @@ outputs:
     description: "Matrix for regular runs"
     value: |
       {
-        "os": [
-          "ubuntu-24.04",
-          "ubuntu-24.04-arm",
-          "macos-15-intel",
-          "macos-15",
-          "windows-2025",
-          "windows-11-arm"
+        "include": [
+          { "os": "ubuntu-24.04",     "platform": "linux",  "arch": "x64"   },
+          { "os": "ubuntu-24.04-arm", "platform": "linux",  "arch": "arm64" },
+          { "os": "macos-15-intel",   "platform": "darwin", "arch": "x64"   },
+          { "os": "macos-15",         "platform": "darwin", "arch": "arm64" },
+          { "os": "windows-2025",     "platform": "win32",  "arch": "x64"   },
+          { "os": "windows-11-arm",   "platform": "win32",  "arch": "arm64" }
         ]
       }
   cache-key:


### PR DESCRIPTION
## Summary
`release.yaml` references `matrix.platform` and `matrix.arch` when:
- naming the binary upload artifact (`addon-${{ matrix.platform }}-${{ matrix.arch }}`)
- forwarding to the toolkit's `attest-addon.yaml` reusable workflow

But `init-workflow/action.yaml`'s `matrix` output only declared `os`. Both fields silently resolved to empty strings, so:
- every matrix cell uploaded to the same artifact name (`addon--`), and
- the attest-addon action failed at input validation (`Input required and not supplied: platform`) — see https://github.com/vadimpiven/node_reqwest/actions/runs/25280231749

Fix: switch the matrix to a single `include` array so each row defines `os`, `platform`, and `arch` in lockstep.

## Test plan
- [x] `mise run check`
- [ ] Tag a release on this branch's merge commit; confirm all six matrix cells produce distinct artifacts and the attest-addon job succeeds