### PR TITLE
fix(release): simplify matrix to single os axis for attest-addon

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: "Upload binary for attest job"
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
         with:
-          name: "addon-${{ matrix.platform }}-${{ matrix.arch }}"
+          name: "addon-${{ matrix.os }}"
           path: "packages/node/dist/*.node.gz"
           if-no-files-found: "error"
   attest-addon:
@@ -114,9 +114,7 @@ jobs:
       attestations: "write" # @actions/attest writes to the GitHub Attestations API
     uses: "vadimpiven/node-addon-slsa/.github/workflows/attest-addon.yaml@05d945b477a6476c12ae4b96cb42d5fbda0748d1" # v0.13.3
     with:
-      binary-artifact: "addon-${{ matrix.platform }}-${{ matrix.arch }}"
-      platform: "${{ matrix.platform }}"
-      arch: "${{ matrix.arch }}"
+      binary-artifact: "addon-${{ matrix.os }}"
   build-packages:
     name: "Build packages"
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- Replace #142's approach. The toolkit's attest-addon reusable workflow (after node-addon-slsa v0.13.4, see vadimpiven/node-addon-slsa#64) derives `platform` / `arch` from `runner.os` / `runner.arch`, so the consumer side collapses to a single `os` matrix axis.
- Build artifact name simplified to `addon-${{ matrix.os }}` (was `addon-${{ matrix.platform }}-${{ matrix.arch }}`).
- `attest-addon` job's `with:` block keeps only `binary-artifact`.
- Reusable workflow refs left at v0.13.3 SHA; SHA bump to v0.13.4 will be a separate, isolated PR after the toolkit tag exists.

Closes #142.

## Test plan

- [ ] CI green on this branch
- [ ] After v0.13.4 SHA bump PR merges, a release run produces `addon-<os>` artifacts and per-cell descriptors with correct platform/arch
🤖 Generated with [Claude Code](https://claude.com/claude-code)