### PR TITLE
chore(deps): bump node-addon-slsa to 0.15.1

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,7 +69,7 @@
     "postinstall": "slsa wget"
   },
   "dependencies": {
-    "node-addon-slsa": "0.15.0"
+    "node-addon-slsa": "0.15.1"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
   packages/node:
     dependencies:
       node-addon-slsa:
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.15.1
+        version: 0.15.1
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-slsa@0.15.0:
-    resolution: {integrity: sha512-iKl/uDDv7DrZaZ5t7tkcbdLMNQBoODG8sifqgl14vpXiaKx2GANJPYnsULCHlgt7zUOw1zw5FsJyZKTNkIWI4Q==}
+  node-addon-slsa@0.15.1:
+    resolution: {integrity: sha512-sLTJzaQvWBC6f063yNuJlt//ZbJ/zIcXvwU3FuHgWZc1fWRE/eBWqzOH2aun8qpbkzOLYxlqAbwI2URpIgSxYg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -4699,7 +4699,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-addon-slsa@0.15.0: {}
+  node-addon-slsa@0.15.1: {}
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
## Summary

Picks up the v0.15.1 fixes:

- **undici redirect-following** — GitHub release-asset URLs always 302
  to release-assets.githubusercontent.com; without redirect handling
  \`slsa wget\` got an empty 302 body and surfaced \"unexpected end of
  file\" mid-gunzip.
- **Rekor ingestion-lag absorption** — Rekor's search index commits
  UUIDs faster than the per-entry endpoint replicates them.
  \`fetchRekorEntry\` now retries 404 inside a 32s wall-clock budget.

These two together unblock the smoke test run right after publish.

No workflow changes needed — the v0.15.x line still ships only the
\`attest-public\` action; node_reqwest's release.yaml has the inlined
publish job from #144.

## Test plan

- [x] \`pnpm install\` regenerates lockfile cleanly
- [x] Pre-commit hooks (lint, format, gitleaks) pass
- [ ] CI green
- [ ] Cut a tag once merged; confirm install + smoke test no longer fail
      on \"unexpected end of file\" or Rekor 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)