### PR TITLE
chore: tighten undici peer range and add socket.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Ask DeepWiki][deepwiki-badge]][deepwiki-site]
 [![CI status][status-badge]][status-dashboard]
 [![Test coverage][coverage-badge]][coverage-dashboard]
+[![Supply-chain score][socket-badge]][socket-dashboard]
 
 [github-badge]: https://img.shields.io/github/stars/vadimpiven/node_reqwest?style=flat&logo=github
 [github-repo]: https://github.com/vadimpiven/node_reqwest
@@ -17,6 +18,8 @@
 [status-dashboard]: https://github.com/vadimpiven/node_reqwest/actions?query=branch%3Amain
 [coverage-badge]: https://img.shields.io/codecov/c/github/vadimpiven/node_reqwest/main?logo=codecov
 [coverage-dashboard]: https://app.codecov.io/gh/vadimpiven/node_reqwest/tree/main
+[socket-badge]: https://badge.socket.dev/npm/package/node-reqwest
+[socket-dashboard]: https://socket.dev/npm/package/node-reqwest
 
 [![Open in GitHub Codespaces][codespace-badge]][codespace-action]
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -4,6 +4,7 @@
 [![Ask DeepWiki][deepwiki-badge]][deepwiki-site]
 [![CI status][status-badge]][status-dashboard]
 [![Test coverage][coverage-badge]][coverage-dashboard]
+[![Supply-chain score][socket-badge]][socket-dashboard]
 
 [github-badge]: https://img.shields.io/github/stars/vadimpiven/node_reqwest?style=flat&logo=github
 [github-repo]: https://github.com/vadimpiven/node_reqwest
@@ -17,6 +18,8 @@
 [status-dashboard]: https://github.com/vadimpiven/node_reqwest/actions?query=branch%3Amain
 [coverage-badge]: https://img.shields.io/codecov/c/github/vadimpiven/node_reqwest/main?logo=codecov
 [coverage-dashboard]: https://app.codecov.io/gh/vadimpiven/node_reqwest/tree/main
+[socket-badge]: https://badge.socket.dev/npm/package/node-reqwest
+[socket-dashboard]: https://socket.dev/npm/package/node-reqwest
 
 # node-reqwest
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -87,7 +87,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "undici": ">=7.0.0"
+    "undici": "^7.0.0 || ^8.0.0"
   },
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Tighten `undici` peer dependency range from `>=7.0.0` to `^7.0.0 || ^8.0.0` so a future undici 9 with breaking changes will not silently satisfy the constraint (catalog currently pins 8.2.0).
- Add Socket.dev supply-chain score badge to the repo README and the published package README.

## Test plan
- [ ] `mise run check` passes
- [ ] Badges render correctly on GitHub and npm
- [ ] Peer dep range still resolves with installed undici 8.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)