### PR TITLE
docs(plan): redesign SBOM/attestation plan around Syft + cargo-auditable

### DIFF
--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -5,29 +5,19 @@
 
 ## Goal
 
-Ship a target-exact CycloneDX 1.6 SBOM with every release artifact, attested through the GitHub
-Attestations API. Rust SBOMs come from the `.dep-v0` section that `cargo-auditable` embeds at link
-time; the JS SBOM comes from `pnpm-lock.yaml` shipped inside the npm tarball. One generator (Syft)
-covers both.
+Ship a target-exact CycloneDX 1.6 SBOM with every release artifact, attested via the GitHub
+Attestations API.
 
-## Publish topology
+## Artifacts
 
-`release.yaml` produces two artifact streams:
+| Artifact                 | Produced by                              | Contents              | SBOM source                         | Generator |
+| ------------------------ | ---------------------------------------- | --------------------- | ----------------------------------- | --------- |
+| `*.node.gz` (per target) | `build-addon` → `gh release upload`      | Compiled Rust binary  | `.dep-v0` section (cargo-auditable) | Syft      |
+| `package.tar.gz`         | `build-packages` → `publish` (npm)       | JS only; no `.node`   | `pnpm-lock.yaml` (shipped)          | Syft      |
 
-- **Per-target `.node.gz`** → `gh release upload` from `build-addon` (one per matrix entry).
-  Contains the compiled Rust binary.
-- **`package.tar.gz`** → `npm publish` from `publish`. JS only (loader, types, `export_dist/`).
-  The `slsa` postinstall fetches the matching `.node.gz` from the GitHub Release.
-
-Rust and JS live in different artifacts, so each gets its own SBOM attested to its own subject.
-Per-target Rust attribution is preserved by construction; no merging required.
-
-## Scope
-
-| Artifact                 | Source of truth                     | Generator | Format        |
-| ------------------------ | ----------------------------------- | --------- | ------------- |
-| `*.node.gz` (per target) | `.dep-v0` section (cargo-auditable) | Syft      | CycloneDX 1.6 |
-| `package.tar.gz` (JS)    | `pnpm-lock.yaml` (shipped)          | Syft      | CycloneDX 1.6 |
+The `slsa` postinstall in the npm package fetches the matching `.node.gz` from the GitHub Release
+at install time. Rust and JS live in different artifacts, so each gets its own SBOM attested to
+its own subject — no merging, per-target Rust attribution preserved by construction.
 
 Not covered: system libraries (none — rustls eliminates OpenSSL), build toolchain (rustc,
 neon-build).
@@ -39,21 +29,24 @@ Combined with `.dep-v0`, it strengthens to *the SBOM reflects what the compiler 
 binary at link time*. Tampering with the binary post-link breaks `cargo audit bin`; tampering with
 the SBOM breaks attestation verification.
 
-A Cargo.lock-only SBOM would be approximate — `[target.'cfg(...)']` deps and feature flags differ
-per platform (rustls vs schannel vs Security.framework). `.dep-v0` is target-exact because each
-binary only embeds the deps the linker actually consumed.
+`.dep-v0` over `Cargo.lock`: feature flags and `[target.'cfg(...)']` deps vary per platform
+(rustls vs schannel vs Security.framework), so a Cargo.lock-derived SBOM would be approximate.
 
-## Changes
+## Implementation steps (commit order)
+
+§5 must land before §6 (which references the mise tasks); otherwise the steps are independent and
+can be split into per-commit PRs as preferred.
 
 ### 1. Install Syft via mise
 
 ```toml
-# mise.toml — add inline alongside existing aqua: pins (mise.toml:43-52)
+# mise.toml — inline alongside existing aqua: pins (mise.toml:43-52)
 "aqua:anchore/syft" = "1.44.0"  # latest stable 2026-05-01
 ```
 
-Pinned directly (not `anchore/sbom-action`, which lags Syft by 1–2 minor versions). Syft ≥ 1.15
-enables `cargo-auditable-binary-cataloger` by default; ≥ 1.8 emits CycloneDX 1.6 by default.
+- Pinned directly, not via `anchore/sbom-action` (lags Syft by 1–2 minors).
+- Syft ≥ 1.15: `cargo-auditable-binary-cataloger` on by default.
+- Syft ≥ 1.8: CycloneDX 1.6 by default.
 
 ### 2. Install cargo-auditable via mise + Dockerfile
 
@@ -73,8 +66,8 @@ windows-arm64 = { asset_pattern = "*-aarch64-pc-windows-msvc.zip" }
 
 ```dockerfile
 # Dockerfile — after mise install (Dockerfile:27-32)
-# Single compile per image rebuild, cached in a Docker layer. Bump --version
-# in lockstep with the mise.toml pin above.
+# Single compile per image rebuild, cached in a Docker layer.
+# Bump --version in lockstep with the mise.toml pin above.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     if [ "$(uname -m)" = "aarch64" ]; then \
       eval "$(mise activate bash)" && \
@@ -83,10 +76,6 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
       cargo-auditable --version; \
     fi
 ```
-
-Linux x86_64 takes the static `musl` asset (runs in any container). macOS/Windows use native
-binaries. Linux arm64 inside manylinux_2_28 has no compatible upstream binary → Dockerfile
-compiles once at image build, layer-cached.
 
 ### 3. Compile all builds with cargo-auditable
 
@@ -99,7 +88,7 @@ compiles once at image build, layer-cached.
 
 `build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release.yaml:86). cargo-auditable
 delegates to `cargo build` and embeds `.dep-v0` post-link — ELF on Linux, Mach-O on macOS, PE on
-Windows. Dev `pnpm run build` uses the same command.
+Windows.
 
 ### 4. Ship pnpm-lock.yaml inside the npm tarball
 
@@ -153,58 +142,44 @@ run = [
 Add `packages/node/dist/node_reqwest.cdx.json` and `packages/node/package.cdx.json` to
 `.gitignore`.
 
-Fixed input paths (`dist/node_reqwest.node`, `package.tar.gz`) and fixed output paths — each
-matrix entry writes one SBOM in its own workspace, and the attest step picks it up by literal
-name. No host-target probing; Syft reads `.dep-v0` from ELF/Mach-O/PE identically. Each `run`
-entry is a single command — no shell idioms, portable across bash, PowerShell, git-bash.
+- **Fixed paths in / out**: each matrix entry writes one SBOM in its own workspace; the attest
+  step picks it up by literal name.
+- **No host-target probing**: Syft reads `.dep-v0` from ELF / Mach-O / PE identically.
+- **One command per `run` entry**: portable across bash, PowerShell, git-bash.
 
-### 6. Verify auditable metadata in build-addon
+### 6. Wire SBOM steps into `release.yaml`
+
+Five new steps across two jobs. Each is a one-liner calling §5's tasks, or an `actions/attest-sbom`
+invocation. Existing release-upload steps stay as-is — SBOMs live in the attestation predicate,
+not as release assets.
 
 ```yaml
-# New step between "Sign and notarize" (release.yaml:87) and "Pack node addon"
-# (release.yaml:91). After sign+notarize ensures signing didn't strip .dep-v0.
+# build-addon: between "Sign and notarize" (release.yaml:87) and "Pack node addon" (:91).
+# After sign+notarize ensures signing didn't strip .dep-v0.
 - name: "Verify auditable metadata"
   shell: "bash"
   run: mise run sbom:verify
-```
 
-### 7. Generate per-target Rust SBOM in build-addon
-
-```yaml
-# New step after "Pack node addon", before "Attest build provenance" (release.yaml:96).
+# build-addon: after "Pack node addon", before "Attest build provenance" (:96).
 - name: "Generate Rust SBOM"
   shell: "bash"
   run: mise run sbom:rust
-```
 
-### 8. Attest Rust SBOM in build-addon
-
-```yaml
-# New step after "Attest build provenance". Per-matrix-entry: exactly one
-# subject and one predicate, so attest-sbom's lack of stem-pairing is moot.
+# build-addon: after "Attest build provenance".
+# Per-matrix-entry: one subject, one predicate — attest-sbom's lack of stem-pairing is moot.
 - name: "Attest Rust SBOM"
   uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
     subject-path: "packages/node/dist/*.node.gz"
     sbom-path: "packages/node/dist/node_reqwest.cdx.json"
-```
 
-### 9. Generate JS SBOM in build-packages
-
-```yaml
-# New step in build-packages, after "Build and pack node package", before
-# "Attest node build provenance".
+# build-packages: after "Build and pack node package", before "Attest node build provenance".
 - name: "Generate JS SBOM"
   shell: "bash"
   run: mise run sbom:js
-```
 
-### 10. Attest JS SBOM
-
-```yaml
-# New step after "Attest node build provenance". The existing release upload
-# in build-packages (release.yaml:155-160) stays as-is: the SBOM lives in
-# the attestation predicate, not as a separate release asset.
+# build-packages: after "Attest node build provenance".
+# Existing release upload (release.yaml:155-160) is unchanged.
 - name: "Attest JS SBOM"
   uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
@@ -212,7 +187,7 @@ entry is a single command — no shell idioms, portable across bash, PowerShell,
     sbom-path: "packages/node/package.cdx.json"
 ```
 
-### 11. Update README
+### 7. Update README
 
 In `packages/node/README.md` > "Installation safety", after existing provenance text:
 
@@ -227,22 +202,27 @@ In `packages/node/README.md` > "Installation safety", after existing provenance 
 >   --format json | jq '.[0].verificationResult.statement.predicate'
 > ```
 
-## Scope of impact
+## Files touched
+
+CI workflows:
 
 - **`regular.yaml`**: unchanged. All builds use `cargo auditable build` via `build:cargo`.
 - **`release.yaml`**:
-  - `build-addon`: two `mise run sbom:*` calls + Rust attestation (§6–8).
-  - `build-packages`: `mise run sbom:js` + JS attestation (§9–10). Release upload unchanged.
-  - `smoke-test`: unchanged. No post-publish SBOM job — build-time validations cover all
-    pipeline failure modes; consumer-side `gh attestation verify` is exercised once in the
-    dry-run checklist.
-- **Local dev**: `mise run sbom:rust` after `pnpm -F packages/node run ci-build`; `mise run
-  sbom:js` after `build:ts`.
-- **node-addon-slsa**: unchanged.
+  - `build-addon`: two `mise run sbom:*` calls + Rust attestation (§6).
+  - `build-packages`: `mise run sbom:js` + JS attestation (§6). Release upload unchanged.
+  - `smoke-test`: unchanged. No post-publish SBOM job — build-time validations cover all pipeline
+    failure modes; consumer-side `gh attestation verify` is exercised once in the dry-run check.
+- **`node-addon-slsa`**: unchanged.
+
+Local dev: `mise run sbom:rust` after `pnpm -F packages/node run ci-build`; `mise run sbom:js`
+after `build:ts`.
+
+Renovate: Syft and cargo-auditable pinned in `mise.toml` are picked up by the existing scheduled
+dependency update workflow — no config changes.
 
 ## Consumer scenarios
 
-### Verify any release artifact
+### Verify a release artifact
 
 ```bash
 gh attestation verify \
@@ -260,9 +240,8 @@ cargo audit bin node_modules/node-reqwest/dist/node_reqwest.node
 
 ### Bulk CVE response
 
-CVE drops for `rustls@0.23.x`. Security team fetches each artifact's attestation, extracts the
-SBOM predicate, greps the affected crate, identifies impacted installations — target-exact, no
-false positives from features compiled out on their platform:
+Pull the SBOM predicate from each artifact's attestation and grep for the affected crate —
+target-exact, no platform-feature false positives.
 
 ```bash
 gh attestation verify <artifact> --owner vadimpiven \
@@ -272,35 +251,23 @@ gh attestation verify <artifact> --owner vadimpiven \
         | select(.name == "rustls") | .version'
 ```
 
-## Implementation order
-
-Sections 1–11 are in commit order. §5 must land before §6–§10 (which reference its tasks);
-otherwise sections are independent and can be split into per-commit PRs as preferred.
-
-After each commit, `mise run check` must pass (Stop hook per `CLAUDE.md`). To validate the
-workflow itself, push a release-candidate tag (`v0.0.0-rc1`) — `release.yaml` triggers on
-`push: tags: v*` and accepts any tag pointing at a `main` commit (release.yaml:31-39).
-
 ## Dry-run checklist
 
-Push `v0.0.0-rc1` and verify:
+`mise run check` must pass after each commit (Stop hook per `CLAUDE.md`). To validate the
+workflow end-to-end, push a release-candidate tag (`v0.0.0-rc1`) — `release.yaml` triggers on
+`push: tags: v*` and accepts any tag pointing at a `main` commit (release.yaml:31-39). Then
+verify:
 
-1. `.dep-v0` present in the binary across all 6 matrix targets (Linux x64/arm64 manylinux,
-   macOS x64/arm64, Windows x64/arm64).
+1. `.dep-v0` present in the binary across all 6 matrix targets (Linux x64/arm64 manylinux, macOS
+   x64/arm64, Windows x64/arm64).
 2. `mise run sbom:verify` succeeds on the signed+notarized binary — signing didn't strip
    `.dep-v0`.
 3. `mise run sbom:rust` emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
 4. `actions/attest-sbom` attestations appear in the public transparency log.
 5. `mise run sbom:js` output contains transitive deps — find resolved versions of indirect
    entries (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` shipped.
-6. `gh attestation verify <artifact> --owner vadimpiven --predicate-type https://cyclonedx.org/bom
-   --format json` succeeds for one `.node.gz` and the `package.tar.gz` — proves the consumer
-   retrieval path. One-time design check; `actions/attest-sbom` already guarantees Sigstore
-   inclusion per run.
-7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — proves the
-   independent-audit path.
+6. `gh attestation verify --predicate-type https://cyclonedx.org/bom --format json` succeeds for
+   one `.node.gz` and the `package.tar.gz`.
+7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz`.
 
 Rollback: `gh release delete v0.0.0-rc1 --cleanup-tag --yes`.
-
-Syft and cargo-auditable pinned in `mise.toml` are picked up by the existing scheduled dependency
-update workflow — no Renovate config changes.

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -55,16 +55,49 @@ binary only embeds the deps the linker actually consumed.
 Pinned directly (not `anchore/sbom-action`, which lags Syft by 1–2 minor versions). Syft ≥ 1.15
 enables `cargo-auditable-binary-cataloger` by default; ≥ 1.8 emits CycloneDX 1.6 by default.
 
-### 2. Install cargo-auditable via mise
+### 2. Install cargo-auditable via mise + Dockerfile
+
+mise installs from upstream GitHub release binaries on every target where one exists. The single
+gap is linux-arm64 inside the manylinux_2_28 build container — upstream's only arm64 Linux binary
+is gnu/glibc 2.39, which won't execute on glibc 2.28. Handle that one case at image-build time
+inside the Dockerfile so there's zero per-CI-run compile.
 
 ```toml
 # mise.toml — add under [tools]
-"cargo:cargo-auditable" = "0.7.4"
+[tools."github:rust-secure-code/cargo-auditable"]
+version = "0.7.4"
+[tools."github:rust-secure-code/cargo-auditable".platforms]
+linux-x64    = { asset_pattern = "*-x86_64-unknown-linux-musl.tar.xz" }
+macos-x64    = { asset_pattern = "*-x86_64-apple-darwin.tar.xz" }
+macos-arm64  = { asset_pattern = "*-aarch64-apple-darwin.tar.xz" }
+windows-x64  = { asset_pattern = "*-x86_64-pc-windows-msvc.zip" }
+windows-arm64 = { asset_pattern = "*-aarch64-pc-windows-msvc.zip" }
+# linux-arm64: no manylinux-compatible upstream binary; installed via Dockerfile
 ```
 
-`cargo:` backend tries `cargo binstall` first (already pinned at `mise.toml:53`), falls back to
-source build. The fallback path is load-bearing on linux-arm64: only published arm64 Linux binary
-is glibc 2.39, our manylinux_2_28 base has glibc 2.28 — binstall fails, source build wins.
+Linux x86_64 uses the `musl` asset — static, runs in any container. macOS and Windows use native
+binaries. No `linux-arm64` entry means mise skips installation on that target; the Dockerfile must
+provide the binary.
+
+In the project Dockerfile at the repo root, after the mise install block (Dockerfile:27-32), add a
+step that installs cargo-auditable into the manylinux image. Run only on the arm64 build (the
+x86_64 build picks it up from mise's musl asset; doing this for both arches is harmless but
+unnecessary):
+
+```dockerfile
+# Dockerfile — after mise install, before user setup
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+      eval "$(mise activate bash)" && \
+      cargo install cargo-auditable --version 0.7.4 --locked \
+        --root /usr/local && \
+      cargo-auditable --version; \
+    fi
+```
+
+Single compile per image rebuild, cached in a Docker layer. Subsequent `docker build` runs reuse
+the layer; CI runs see a pre-installed binary. Bump `--version` in lockstep with the mise.toml pin
+when upgrading.
 
 ### 3. Compile release builds with cargo-auditable
 

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -114,81 +114,11 @@ command. `build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release
 cargo-auditable runs wherever that runs (host on macOS/Windows, manylinux Docker on Linux). PE
 binaries on Windows get `.dep-v0` in a PE section, same mechanism as ELF/Mach-O.
 
-### 4. Verify auditable metadata in build-addon
+### 4. Ship pnpm-lock.yaml inside the npm tarball
 
-New step in `release.yaml > build-addon`, between "Sign and notarize" (release.yaml:87) and "Pack
-node addon" (release.yaml:91). Placement matters: running after sign+notarize verifies signing did
-not strip `.dep-v0`.
-
-```yaml
-- name: "Verify auditable metadata"
-  uses: "./.github/actions/shell"
-  with:
-    docker-service: ${{ needs.init.outputs.docker-service }}
-    run: |
-      cargo auditable info packages/node/dist/node_reqwest.node
-```
-
-Exits non-zero if `.dep-v0` is missing — fails the release rather than shipping an SBOM-blind
-binary.
-
-### 5. Generate per-target Rust SBOM in build-addon
-
-New steps after "Pack node addon", before "Attest build provenance" (release.yaml:96). Each
-matrix entry produces exactly one `.node.gz` named
-`dist/node_reqwest-v{version}-{platform}-{arch}.node.gz`.
-
-```yaml
-- name: "Generate Rust SBOM"
-  shell: "bash"
-  run: |
-    mkdir -p packages/node/dist/sbom
-    f=(packages/node/dist/*.node.gz)
-    base="$(basename "${f[0]}" .node.gz)"
-    syft scan "file:${f[0]}" \
-      --override-default-catalogers cargo-auditable-binary-cataloger \
-      -o cyclonedx-json="packages/node/dist/sbom/${base}.cdx.json"
-- name: "Validate Rust SBOM"
-  shell: "bash"
-  run: |
-    sbom=(packages/node/dist/sbom/*.cdx.json)
-    jq -e '.bomFormat == "CycloneDX"' "${sbom[0]}"
-    # Catches the empty-SBOM failure mode if Syft's default cataloger selection
-    # changes upstream and deselects cargo-auditable silently.
-    jq -e '
-      [.components[]?
-        | select(.properties[]?.value
-          == "cargo-auditable-binary-cataloger")
-      ] | length > 50
-    ' "${sbom[0]}"
-```
-
-Runs on host shell, not Docker — Syft is verification-only; mise installs it on the runner. `syft
-scan file:...` auto-extracts the `.gz`. Explicit cataloger override defends against
-anchore/syft#2031 (default selection occasionally deselects binary catalogers). Works identically
-for Mach-O, ELF, and PE.
-
-### 6. Attest Rust SBOM in build-addon
-
-New step after "Attest build provenance":
-
-```yaml
-- name: "Attest Rust SBOM"
-  uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
-  with:
-    subject-path: "packages/node/dist/*.node.gz"
-    sbom-path: "packages/node/dist/sbom/*.cdx.json"
-```
-
-`actions/attest-sbom` loads one SBOM as predicate and attaches it to all matched subjects (no
-stem-pairing). Per-matrix-entry, both globs resolve to a single file — single-subject,
-single-predicate, no ambiguity.
-
-### 7. Generate JS SBOM in build-packages
-
-Ship the lockfile inside the tarball so Syft's pnpm cataloger sees the full resolved tree (without
-it, only direct deps from `package.json` appear). `pnpm pack` resolves `files` relative to the
-package directory — so copy the root lockfile in before pack:
+Without the lockfile inside `package.tar.gz`, Syft's pnpm cataloger only sees direct deps from
+`package.json`. `pnpm pack` resolves `files` relative to the package dir, so copy the root
+lockfile in before pack:
 
 ```jsonc
 // packages/node/package.json
@@ -203,41 +133,115 @@ package directory — so copy the root lockfile in before pack:
 Add `packages/node/pnpm-lock.yaml` to `.gitignore` (transient copy; source of truth stays at repo
 root).
 
-New steps in `release.yaml > build-packages`, after "Build and pack node package", before "Attest
-node build provenance":
+### 5. Define mise SBOM tasks
 
-```yaml
-- name: "Generate JS SBOM"
-  shell: "bash"
-  run: |
-    syft scan "file:packages/node/package.tar.gz" \
-      -o cyclonedx-json="packages/node/node_reqwest-${GITHUB_REF_NAME}-js.cdx.json"
-- name: "Validate JS SBOM"
-  shell: "bash"
-  run: |
-    jq -e '.bomFormat == "CycloneDX"' \
-      packages/node/node_reqwest-*-js.cdx.json
-    jq -e '
-      [.components[]? | select(.type == "library")] | length > 0
-    ' packages/node/node_reqwest-*-js.cdx.json
+All SBOM work — verify, generate, validate — lives in `mise.toml` as portable tasks. CI calls them
+verbatim; local dev calls them verbatim. Same code path, same outputs, both platforms (bash,
+PowerShell, git-bash on Windows runners).
+
+```toml
+# mise.toml
+
+# Verify cargo-auditable embedded .dep-v0. Exits non-zero if missing.
+[tasks."sbom:verify"]
+description = "Check .dep-v0 is present in the built addon"
+run = "cargo auditable info packages/node/dist/node_reqwest.node"
+
+# Generate Rust SBOM from the addon binary (always at this fixed path post-build).
+[tasks."sbom:rust"]
+description = "Generate CycloneDX SBOM from the addon's .dep-v0 section"
+depends = ["sbom:verify"]
+run = [
+  '''syft scan packages/node/dist/node_reqwest.node --override-default-catalogers cargo-auditable-binary-cataloger -o cyclonedx-json=packages/node/dist/node_reqwest.cdx.json''',
+  '''jq -e '.bomFormat == "CycloneDX"' packages/node/dist/node_reqwest.cdx.json''',
+  '''jq -e '[.components[]? | select(.properties[]?.value == "cargo-auditable-binary-cataloger")] | length > 50' packages/node/dist/node_reqwest.cdx.json''',
+]
+
+# Generate JS SBOM from the packed tarball (always at this fixed path post-pack).
+[tasks."sbom:js"]
+description = "Generate CycloneDX SBOM from the packed npm tarball"
+run = [
+  '''syft scan packages/node/package.tar.gz -o cyclonedx-json=packages/node/package.cdx.json''',
+  '''jq -e '.bomFormat == "CycloneDX"' packages/node/package.cdx.json''',
+  '''jq -e '[.components[]? | select(.type == "library")] | length > 0' packages/node/package.cdx.json''',
+]
 ```
 
-### 8. Attest JS SBOM
+Add `packages/node/dist/node_reqwest.cdx.json` and `packages/node/package.cdx.json` to
+`.gitignore`.
 
-New step after "Attest node build provenance":
+Portability notes:
+
+- Each `run` entry is a single command — no bash loops, no glob expansion, no host-target probing.
+  The addon is always at `packages/node/dist/node_reqwest.node` regardless of target (Linux/macOS
+  `.so/.dylib` get renamed to `.node` by the build); Syft reads `.dep-v0` from ELF / Mach-O / PE
+  with the same invocation.
+- TOML triple-single-quote literals carry jq filters unescaped.
+- Output paths are fixed — no `${GITHUB_REF_NAME}` or per-target naming. Each matrix entry writes
+  its own `node_reqwest.cdx.json` in its own runner workspace; the attest step picks it up by
+  literal path.
+
+### 6. Verify auditable metadata in build-addon
 
 ```yaml
+# New step between "Sign and notarize" (release.yaml:87) and "Pack node addon"
+# (release.yaml:91). After sign+notarize ensures signing didn't strip .dep-v0.
+- name: "Verify auditable metadata"
+  shell: "bash"
+  run: mise run sbom:verify
+```
+
+### 7. Generate per-target Rust SBOM in build-addon
+
+```yaml
+# New step after "Pack node addon", before "Attest build provenance" (release.yaml:96).
+- name: "Generate Rust SBOM"
+  shell: "bash"
+  run: mise run sbom:rust
+```
+
+Each matrix entry produces one `.node` (the source) and one `.cdx.json` (the SBOM) in its own
+workspace.
+
+### 8. Attest Rust SBOM in build-addon
+
+```yaml
+# New step after "Attest build provenance".
+- name: "Attest Rust SBOM"
+  uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
+  with:
+    subject-path: "packages/node/dist/*.node.gz"
+    sbom-path: "packages/node/dist/node_reqwest.cdx.json"
+```
+
+`actions/attest-sbom` loads one SBOM as predicate and attaches it to all matched subjects (no
+stem-pairing). Per-matrix-entry, exactly one subject and one predicate.
+
+### 9. Generate JS SBOM in build-packages
+
+```yaml
+# New step in build-packages, after "Build and pack node package", before
+# "Attest node build provenance".
+- name: "Generate JS SBOM"
+  shell: "bash"
+  run: mise run sbom:js
+```
+
+### 10. Attest JS SBOM
+
+```yaml
+# New step after "Attest node build provenance".
 - name: "Attest JS SBOM"
   uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
     subject-path: "packages/node/package.tar.gz"
-    sbom-path: "packages/node/node_reqwest-*-js.cdx.json"
+    sbom-path: "packages/node/package.cdx.json"
 ```
 
 Existing upload step in `build-packages` (release.yaml:155-160) is unchanged — SBOMs live in the
 attestation predicate, not as separate release assets.
 
-### 9. New job: smoke-sbom
+### 11. New job: smoke-sbom
 
 Add a top-level job under `jobs:` in `release.yaml`, alongside the existing `smoke-test`
 (release.yaml:203). Single-runner since SBOM/attestation verification doesn't depend on OS.
@@ -287,33 +291,7 @@ smoke-sbom:
 including the SBOM predicate — no separate SBOM download needed since the SBOM lives in the
 attestation, not as a release asset.
 
-### 10. Add local mise task
-
-```toml
-# mise.toml — workspace target dir is at repo root (./target/)
-[tasks.sbom]
-description = "Generate CycloneDX SBOM for node package (release build)"
-depends = ["setup:rust"]
-run = """
-cargo auditable build -r --locked -p node
-bin=""
-for candidate in target/release/libnode_reqwest.so \
-                 target/release/libnode_reqwest.dylib \
-                 target/release/node_reqwest.dll; do
-  [ -f "$candidate" ] && bin="$candidate" && break
-done
-[ -n "$bin" ] || { echo "no built artifact found"; exit 1; }
-syft scan "file:$bin" \
-  --override-default-catalogers cargo-auditable-binary-cataloger \
-  -o cyclonedx-json=bom.json
-jq -e '.components | length' bom.json
-"""
-sources = ["Cargo.lock", "packages/*/Cargo.toml"]
-```
-
-Add `/bom.json` to `.gitignore`.
-
-### 11. Update README
+### 12. Update README
 
 In `packages/node/README.md` > "Installation safety", after existing provenance text:
 
@@ -333,13 +311,13 @@ In `packages/node/README.md` > "Installation safety", after existing provenance 
 - **`regular.yaml`**: unchanged in workflow logic. All builds (dev + CI) now go through
   `cargo auditable build` via `build:cargo` — negligible overhead, single code path.
 - **`release.yaml`**:
-  - `build-addon`: `cargo auditable build`, verify metadata, per-target Syft SBOM, attestation
-    (§3–6). Existing release upload unchanged — SBOMs live in the attestation predicate.
-  - `build-packages`: lockfile-bundled tarball, Syft scan, JS SBOM attestation (§7–8). Existing
-    release upload unchanged.
-  - `smoke-sbom` (new): single-runner attestation verification + SBOM extraction (§9).
+  - `build-addon`: three `mise run sbom:*` calls (verify, rust) + Rust attestation (§6–8).
+  - `build-packages`: lockfile bundling (§4) + `mise run sbom:js` + JS attestation (§9–10).
+    Existing release upload unchanged — SBOMs live in the attestation predicate.
+  - `smoke-sbom` (new): single-runner attestation verification + SBOM extraction (§11).
   - `smoke-test`: unchanged.
-- **Local dev**: `mise run sbom` produces a host-target CycloneDX SBOM (§10).
+- **Local dev**: `mise run sbom:rust` (after `pnpm -F packages/node run ci-build`) produces a
+  host-target SBOM. `mise run sbom:js` runs after `build:ts` produces the tarball.
 - **node-addon-slsa**: unchanged.
 
 ## Consumer scenarios
@@ -376,16 +354,18 @@ gh attestation verify <artifact> --owner vadimpiven \
 
 ## Implementation order
 
-Sections 1–11 are written in commit order:
+Sections 1–12 are written in commit order:
 
 - §1 + §2 (mise pins + Dockerfile bake) land first — subsequent CI changes assume the tools are
   installed.
-- §3 + §4 are tightly coupled (auditable build + verify) — land together.
-- §5 + §6 extend `build-addon` (Rust SBOM gen, attest).
-- §7 + §8 extend `build-packages` (JS SBOM gen, attest).
-- §9 adds the verification job.
-- §10 is local-dev convenience — lands anytime.
-- §11 (README) lands last.
+- §3 (cargo-auditable in build:cargo) lands next — it's a one-line edit that all later sections
+  depend on.
+- §4 (ship lockfile) is independent of §3 but small — bundle either way.
+- §5 (mise tasks) defines the building blocks. Must land before §6–§10 which reference them.
+- §6 + §7 + §8 extend `build-addon` (verify, Rust SBOM gen, Rust attest).
+- §9 + §10 extend `build-packages` (JS SBOM gen, JS attest).
+- §11 adds the verification job.
+- §12 (README) lands last.
 
 After each set of CI changes, `mise run check` must pass (gate enforced by the Stop hook per
 `CLAUDE.md`). To validate the actual workflow, push a release-candidate tag (e.g. `v0.0.0-rc1`) —
@@ -398,13 +378,14 @@ Before the first real `v*` release tag, push a release-candidate tag and verify:
 
 1. `build-addon` produces `.dep-v0` in the binary across all matrix targets (Linux x64/arm64
    manylinux, macOS x64/arm64, Windows x64/arm64).
-2. `cargo auditable info` (§4) succeeds on the signed+notarized binary — confirms signing
+2. `mise run sbom:verify` (§6) succeeds on the signed+notarized binary — confirms signing
    preserves `.dep-v0`.
-3. Syft (§5) emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
+3. `mise run sbom:rust` (§7) emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
 4. `actions/attest-sbom` attestations appear in the public transparency log.
-5. JS SBOM (§7) contains transitive deps — look for resolved versions of indirect entries
-   (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` was bundled.
-6. `smoke-sbom` (§9) passes end-to-end — attestation verifies AND the embedded SBOM predicate
+5. `mise run sbom:js` output (§9) contains transitive deps — look for resolved versions of
+   indirect entries (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` was
+   bundled.
+6. `smoke-sbom` (§11) passes end-to-end — attestation verifies AND the embedded SBOM predicate
    is well-formed CycloneDX.
 7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — confirms
    consumers can audit independently.

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -78,7 +78,13 @@ Windows.
 
 Without the lockfile inside `package.tar.gz`, Syft's pnpm cataloger only sees direct deps from
 `package.json`. `pnpm pack` resolves `files` relative to the package dir, so copy the root
-lockfile in before pack:
+lockfile in before pack. Use `shx` for a portable `cp` (the project has Windows dev runners; bare
+`cp` breaks there).
+
+```yaml
+# pnpm-workspace.yaml — add to catalog: section (exact pin, per project convention)
+shx: 0.4.0
+```
 
 ```jsonc
 // packages/node/package.json
@@ -87,7 +93,14 @@ lockfile in before pack:
   "export_dist/**/*",
   "pnpm-lock.yaml"
 ],
-"build:ts": "vite build && typedoc && cp ../../pnpm-lock.yaml . && pnpm pack --out package.tar.gz"
+"devDependencies": {
+  "shx": "catalog:"
+  // ...existing entries
+},
+"scripts": {
+  "build:ts": "vite build && typedoc && shx cp ../../pnpm-lock.yaml . && pnpm pack --out package.tar.gz"
+  // ...
+}
 ```
 
 Add `packages/node/pnpm-lock.yaml` to `.gitignore` (transient copy; source of truth stays at repo
@@ -98,16 +111,21 @@ root).
 All SBOM work lives in `mise.toml`. CI and local dev call the same tasks.
 
 ```toml
-# mise.toml
+# mise.toml — all three tasks set shell="bash -c" because the jq filters use
+# single-quoted args. mise on Windows defaults to cmd.exe, which doesn't strip
+# single quotes, so the filter would reach jq with stray quotes. git-bash is
+# available on GitHub Actions Windows runners and on any Git-for-Windows dev box.
 
 # Exits non-zero if .dep-v0 missing.
 [tasks."sbom:verify"]
 description = "Check .dep-v0 is present in the built addon"
+shell = "bash -c"
 run = "cargo auditable info packages/node/dist/node_reqwest.node"
 
 [tasks."sbom:rust"]
 description = "Generate CycloneDX SBOM from the addon's .dep-v0 section"
 depends = ["sbom:verify"]
+shell = "bash -c"
 run = [
   '''syft scan packages/node/dist/node_reqwest.node --override-default-catalogers cargo-auditable-binary-cataloger -o cyclonedx-json=packages/node/dist/node_reqwest.cdx.json''',
   '''jq -e '.bomFormat == "CycloneDX"' packages/node/dist/node_reqwest.cdx.json''',
@@ -116,6 +134,7 @@ run = [
 
 [tasks."sbom:js"]
 description = "Generate CycloneDX SBOM from the packed npm tarball"
+shell = "bash -c"
 run = [
   '''syft scan packages/node/package.tar.gz -o cyclonedx-json=packages/node/package.cdx.json''',
   '''jq -e '.bomFormat == "CycloneDX"' packages/node/package.cdx.json''',
@@ -129,7 +148,7 @@ Add `packages/node/dist/node_reqwest.cdx.json` and `packages/node/package.cdx.js
 - **Fixed paths in / out**: each matrix entry writes one SBOM in its own workspace; the attest
   step picks it up by literal name.
 - **No host-target probing**: Syft reads `.dep-v0` from ELF / Mach-O / PE identically.
-- **One command per `run` entry**: portable across bash, PowerShell, git-bash.
+- **bash on all platforms**: `shell = "bash -c"` per task — uses git-bash on Windows.
 
 ### 6. Wire SBOM steps into `release.yaml`
 

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -48,34 +48,18 @@ can be split into per-commit PRs as preferred.
 - Syft ≥ 1.15: `cargo-auditable-binary-cataloger` on by default.
 - Syft ≥ 1.8: CycloneDX 1.6 by default.
 
-### 2. Install cargo-auditable via mise + Dockerfile
+### 2. Install cargo-auditable via mise
 
 ```toml
 # mise.toml — add under [tools]
-[tools."github:rust-secure-code/cargo-auditable"]
-version = "0.7.4"
-[tools."github:rust-secure-code/cargo-auditable".platforms]
-linux-x64    = { asset_pattern = "*-x86_64-unknown-linux-musl.tar.xz" }
-macos-x64    = { asset_pattern = "*-x86_64-apple-darwin.tar.xz" }
-macos-arm64  = { asset_pattern = "*-aarch64-apple-darwin.tar.xz" }
-windows-x64  = { asset_pattern = "*-x86_64-pc-windows-msvc.zip" }
-windows-arm64 = { asset_pattern = "*-aarch64-pc-windows-msvc.zip" }
-# linux-arm64: no manylinux-compatible upstream binary (only gnu/glibc 2.39
-# exists; our manylinux_2_28 base has glibc 2.28). Installed via Dockerfile.
+"cargo:cargo-auditable" = "0.7.4"
 ```
 
-```dockerfile
-# Dockerfile — after mise install (Dockerfile:27-32)
-# Single compile per image rebuild, cached in a Docker layer.
-# Bump --version in lockstep with the mise.toml pin above.
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    if [ "$(uname -m)" = "aarch64" ]; then \
-      eval "$(mise activate bash)" && \
-      cargo install cargo-auditable --version 0.7.4 --locked \
-        --root /usr/local && \
-      cargo-auditable --version; \
-    fi
-```
+`cargo:` backend tries `cargo binstall` first (already pinned at `mise.toml:53`) and succeeds on
+5 of 6 targets via upstream release binaries. Falls back to source build only on linux-arm64
+inside the manylinux_2_28 container, where no compatible upstream binary exists (only gnu/glibc
+2.39 is published; our base has glibc 2.28). The fallback is one small Rust compile cached by
+mise — no Dockerfile changes needed.
 
 ### 3. Compile all builds with cargo-auditable
 

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -241,57 +241,7 @@ stem-pairing). Per-matrix-entry, exactly one subject and one predicate.
 Existing upload step in `build-packages` (release.yaml:155-160) is unchanged — SBOMs live in the
 attestation predicate, not as separate release assets.
 
-### 11. New job: smoke-sbom
-
-Add a top-level job under `jobs:` in `release.yaml`, alongside the existing `smoke-test`
-(release.yaml:203). Single-runner since SBOM/attestation verification doesn't depend on OS.
-
-```yaml
-smoke-sbom:
-  name: "Smoke test SBOM"
-  timeout-minutes: 5
-  permissions:
-    contents: "read"
-  needs:
-    - "publish"
-  if: needs.publish.result == 'success'
-  runs-on: "ubuntu-latest"
-  steps:
-    - name: "Download release artifacts"
-      shell: "bash"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        mkdir -p sbom-check && cd sbom-check
-        gh release download "$GITHUB_REF_NAME" \
-          --repo vadimpiven/node_reqwest \
-          --pattern "*.node.gz" \
-          --pattern "package.tar.gz"
-    - name: "Verify attestation + extract SBOM"
-      shell: "bash"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd sbom-check
-        for artifact in *.node.gz package.tar.gz; do
-          # Verifies signature + transparency log inclusion, returns the
-          # attestation bundle (which embeds the SBOM as its predicate).
-          gh attestation verify "$artifact" \
-            --owner vadimpiven \
-            --predicate-type https://cyclonedx.org/bom \
-            --format json > "${artifact}.attestation.json"
-          # Extract the SBOM predicate and validate its shape.
-          jq -e '.[0].verificationResult.statement.predicate.bomFormat == "CycloneDX"' \
-            "${artifact}.attestation.json"
-        done
-```
-
-`gh attestation verify` reads the public transparency log; default `contents: read` is sufficient.
-`GITHUB_TOKEN` env is for rate limits only. The verify call returns the full attestation bundle
-including the SBOM predicate — no separate SBOM download needed since the SBOM lives in the
-attestation, not as a release asset.
-
-### 12. Update README
+### 11. Update README
 
 In `packages/node/README.md` > "Installation safety", after existing provenance text:
 
@@ -311,11 +261,12 @@ In `packages/node/README.md` > "Installation safety", after existing provenance 
 - **`regular.yaml`**: unchanged in workflow logic. All builds (dev + CI) now go through
   `cargo auditable build` via `build:cargo` — negligible overhead, single code path.
 - **`release.yaml`**:
-  - `build-addon`: three `mise run sbom:*` calls (verify, rust) + Rust attestation (§6–8).
+  - `build-addon`: two `mise run sbom:*` calls (verify, rust) + Rust attestation (§6–8).
   - `build-packages`: lockfile bundling (§4) + `mise run sbom:js` + JS attestation (§9–10).
     Existing release upload unchanged — SBOMs live in the attestation predicate.
-  - `smoke-sbom` (new): single-runner attestation verification + SBOM extraction (§11).
-  - `smoke-test`: unchanged.
+  - `smoke-test`: unchanged. No post-publish SBOM check job — build-time validations cover all
+    pipeline failure modes; consumer-side `gh attestation verify` is exercised in the dry-run
+    checklist instead.
 - **Local dev**: `mise run sbom:rust` (after `pnpm -F packages/node run ci-build`) produces a
   host-target SBOM. `mise run sbom:js` runs after `build:ts` produces the tarball.
 - **node-addon-slsa**: unchanged.
@@ -354,18 +305,16 @@ gh attestation verify <artifact> --owner vadimpiven \
 
 ## Implementation order
 
-Sections 1–12 are written in commit order:
+Sections 1–11 are written in commit order:
 
 - §1 + §2 (mise pins + Dockerfile bake) land first — subsequent CI changes assume the tools are
   installed.
-- §3 (cargo-auditable in build:cargo) lands next — it's a one-line edit that all later sections
-  depend on.
+- §3 (cargo-auditable in build:cargo) lands next — one-line edit that later sections depend on.
 - §4 (ship lockfile) is independent of §3 but small — bundle either way.
 - §5 (mise tasks) defines the building blocks. Must land before §6–§10 which reference them.
 - §6 + §7 + §8 extend `build-addon` (verify, Rust SBOM gen, Rust attest).
 - §9 + §10 extend `build-packages` (JS SBOM gen, JS attest).
-- §11 adds the verification job.
-- §12 (README) lands last.
+- §11 (README) lands last.
 
 After each set of CI changes, `mise run check` must pass (gate enforced by the Stop hook per
 `CLAUDE.md`). To validate the actual workflow, push a release-candidate tag (e.g. `v0.0.0-rc1`) —
@@ -385,8 +334,11 @@ Before the first real `v*` release tag, push a release-candidate tag and verify:
 5. `mise run sbom:js` output (§9) contains transitive deps — look for resolved versions of
    indirect entries (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` was
    bundled.
-6. `smoke-sbom` (§11) passes end-to-end — attestation verifies AND the embedded SBOM predicate
-   is well-formed CycloneDX.
+6. `gh attestation verify <artifact> --owner vadimpiven --predicate-type https://cyclonedx.org/bom
+   --format json` succeeds for at least one `.node.gz` and the `package.tar.gz` — confirms the
+   consumer-facing retrieval path works end-to-end. (One-time design check, not a per-release CI
+   job — `actions/attest-sbom` succeeding in the workflow already guarantees the attestation is
+   in Sigstore.)
 7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — confirms
    consumers can audit independently.
 

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -57,11 +57,6 @@ enables `cargo-auditable-binary-cataloger` by default; ≥ 1.8 emits CycloneDX 1
 
 ### 2. Install cargo-auditable via mise + Dockerfile
 
-mise installs from upstream GitHub release binaries on every target where one exists. The single
-gap is linux-arm64 inside the manylinux_2_28 build container — upstream's only arm64 Linux binary
-is gnu/glibc 2.39, which won't execute on glibc 2.28. Handle that one case at image-build time
-inside the Dockerfile so there's zero per-CI-run compile.
-
 ```toml
 # mise.toml — add under [tools]
 [tools."github:rust-secure-code/cargo-auditable"]
@@ -72,20 +67,14 @@ macos-x64    = { asset_pattern = "*-x86_64-apple-darwin.tar.xz" }
 macos-arm64  = { asset_pattern = "*-aarch64-apple-darwin.tar.xz" }
 windows-x64  = { asset_pattern = "*-x86_64-pc-windows-msvc.zip" }
 windows-arm64 = { asset_pattern = "*-aarch64-pc-windows-msvc.zip" }
-# linux-arm64: no manylinux-compatible upstream binary; installed via Dockerfile
+# linux-arm64: no manylinux-compatible upstream binary (only gnu/glibc 2.39
+# exists; our manylinux_2_28 base has glibc 2.28). Installed via Dockerfile.
 ```
 
-Linux x86_64 uses the `musl` asset — static, runs in any container. macOS and Windows use native
-binaries. No `linux-arm64` entry means mise skips installation on that target; the Dockerfile must
-provide the binary.
-
-In the project Dockerfile at the repo root, after the mise install block (Dockerfile:27-32), add a
-step that installs cargo-auditable into the manylinux image. Run only on the arm64 build (the
-x86_64 build picks it up from mise's musl asset; doing this for both arches is harmless but
-unnecessary):
-
 ```dockerfile
-# Dockerfile — after mise install, before user setup
+# Dockerfile — after mise install (Dockerfile:27-32)
+# Single compile per image rebuild, cached in a Docker layer. Bump --version
+# in lockstep with the mise.toml pin above.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     if [ "$(uname -m)" = "aarch64" ]; then \
       eval "$(mise activate bash)" && \
@@ -95,24 +84,22 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     fi
 ```
 
-Single compile per image rebuild, cached in a Docker layer. Subsequent `docker build` runs reuse
-the layer; CI runs see a pre-installed binary. Bump `--version` in lockstep with the mise.toml pin
-when upgrading.
+Linux x86_64 takes the static `musl` asset (runs in any container). macOS/Windows use native
+binaries. Linux arm64 inside manylinux_2_28 has no compatible upstream binary → Dockerfile
+compiles once at image build, layer-cached.
 
 ### 3. Compile all builds with cargo-auditable
 
 ```jsonc
-// packages/node/package.json — patch build:cargo (currently line 53)
+// packages/node/package.json — patch build:cargo (line 53)
 "build:cargo": "cargo auditable build",
-// ci-build stays as-is (line 64); -r --locked are forwarded to cargo auditable build:
+// ci-build (line 64) unchanged; -r --locked forward to cargo auditable build.
 "ci-build": "pnpm run build:cargo -r --locked && pnpm run build:ts"
 ```
 
-cargo-auditable is a thin wrapper that delegates to `cargo build` and embeds a compressed dep
-manifest into a binary section — overhead is negligible, so dev and release builds use the same
-command. `build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release.yaml:86);
-cargo-auditable runs wherever that runs (host on macOS/Windows, manylinux Docker on Linux). PE
-binaries on Windows get `.dep-v0` in a PE section, same mechanism as ELF/Mach-O.
+`build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release.yaml:86). cargo-auditable
+delegates to `cargo build` and embeds `.dep-v0` post-link — ELF on Linux, Mach-O on macOS, PE on
+Windows. Dev `pnpm run build` uses the same command.
 
 ### 4. Ship pnpm-lock.yaml inside the npm tarball
 
@@ -135,19 +122,16 @@ root).
 
 ### 5. Define mise SBOM tasks
 
-All SBOM work — verify, generate, validate — lives in `mise.toml` as portable tasks. CI calls them
-verbatim; local dev calls them verbatim. Same code path, same outputs, both platforms (bash,
-PowerShell, git-bash on Windows runners).
+All SBOM work lives in `mise.toml`. CI and local dev call the same tasks.
 
 ```toml
 # mise.toml
 
-# Verify cargo-auditable embedded .dep-v0. Exits non-zero if missing.
+# Exits non-zero if .dep-v0 missing.
 [tasks."sbom:verify"]
 description = "Check .dep-v0 is present in the built addon"
 run = "cargo auditable info packages/node/dist/node_reqwest.node"
 
-# Generate Rust SBOM from the addon binary (always at this fixed path post-build).
 [tasks."sbom:rust"]
 description = "Generate CycloneDX SBOM from the addon's .dep-v0 section"
 depends = ["sbom:verify"]
@@ -157,7 +141,6 @@ run = [
   '''jq -e '[.components[]? | select(.properties[]?.value == "cargo-auditable-binary-cataloger")] | length > 50' packages/node/dist/node_reqwest.cdx.json''',
 ]
 
-# Generate JS SBOM from the packed tarball (always at this fixed path post-pack).
 [tasks."sbom:js"]
 description = "Generate CycloneDX SBOM from the packed npm tarball"
 run = [
@@ -170,16 +153,10 @@ run = [
 Add `packages/node/dist/node_reqwest.cdx.json` and `packages/node/package.cdx.json` to
 `.gitignore`.
 
-Portability notes:
-
-- Each `run` entry is a single command — no bash loops, no glob expansion, no host-target probing.
-  The addon is always at `packages/node/dist/node_reqwest.node` regardless of target (Linux/macOS
-  `.so/.dylib` get renamed to `.node` by the build); Syft reads `.dep-v0` from ELF / Mach-O / PE
-  with the same invocation.
-- TOML triple-single-quote literals carry jq filters unescaped.
-- Output paths are fixed — no `${GITHUB_REF_NAME}` or per-target naming. Each matrix entry writes
-  its own `node_reqwest.cdx.json` in its own runner workspace; the attest step picks it up by
-  literal path.
+Fixed input paths (`dist/node_reqwest.node`, `package.tar.gz`) and fixed output paths — each
+matrix entry writes one SBOM in its own workspace, and the attest step picks it up by literal
+name. No host-target probing; Syft reads `.dep-v0` from ELF/Mach-O/PE identically. Each `run`
+entry is a single command — no shell idioms, portable across bash, PowerShell, git-bash.
 
 ### 6. Verify auditable metadata in build-addon
 
@@ -200,22 +177,17 @@ Portability notes:
   run: mise run sbom:rust
 ```
 
-Each matrix entry produces one `.node` (the source) and one `.cdx.json` (the SBOM) in its own
-workspace.
-
 ### 8. Attest Rust SBOM in build-addon
 
 ```yaml
-# New step after "Attest build provenance".
+# New step after "Attest build provenance". Per-matrix-entry: exactly one
+# subject and one predicate, so attest-sbom's lack of stem-pairing is moot.
 - name: "Attest Rust SBOM"
   uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
     subject-path: "packages/node/dist/*.node.gz"
     sbom-path: "packages/node/dist/node_reqwest.cdx.json"
 ```
-
-`actions/attest-sbom` loads one SBOM as predicate and attaches it to all matched subjects (no
-stem-pairing). Per-matrix-entry, exactly one subject and one predicate.
 
 ### 9. Generate JS SBOM in build-packages
 
@@ -230,16 +202,15 @@ stem-pairing). Per-matrix-entry, exactly one subject and one predicate.
 ### 10. Attest JS SBOM
 
 ```yaml
-# New step after "Attest node build provenance".
+# New step after "Attest node build provenance". The existing release upload
+# in build-packages (release.yaml:155-160) stays as-is: the SBOM lives in
+# the attestation predicate, not as a separate release asset.
 - name: "Attest JS SBOM"
   uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
     subject-path: "packages/node/package.tar.gz"
     sbom-path: "packages/node/package.cdx.json"
 ```
-
-Existing upload step in `build-packages` (release.yaml:155-160) is unchanged — SBOMs live in the
-attestation predicate, not as separate release assets.
 
 ### 11. Update README
 
@@ -258,17 +229,15 @@ In `packages/node/README.md` > "Installation safety", after existing provenance 
 
 ## Scope of impact
 
-- **`regular.yaml`**: unchanged in workflow logic. All builds (dev + CI) now go through
-  `cargo auditable build` via `build:cargo` — negligible overhead, single code path.
+- **`regular.yaml`**: unchanged. All builds use `cargo auditable build` via `build:cargo`.
 - **`release.yaml`**:
-  - `build-addon`: two `mise run sbom:*` calls (verify, rust) + Rust attestation (§6–8).
-  - `build-packages`: lockfile bundling (§4) + `mise run sbom:js` + JS attestation (§9–10).
-    Existing release upload unchanged — SBOMs live in the attestation predicate.
-  - `smoke-test`: unchanged. No post-publish SBOM check job — build-time validations cover all
-    pipeline failure modes; consumer-side `gh attestation verify` is exercised in the dry-run
-    checklist instead.
-- **Local dev**: `mise run sbom:rust` (after `pnpm -F packages/node run ci-build`) produces a
-  host-target SBOM. `mise run sbom:js` runs after `build:ts` produces the tarball.
+  - `build-addon`: two `mise run sbom:*` calls + Rust attestation (§6–8).
+  - `build-packages`: `mise run sbom:js` + JS attestation (§9–10). Release upload unchanged.
+  - `smoke-test`: unchanged. No post-publish SBOM job — build-time validations cover all
+    pipeline failure modes; consumer-side `gh attestation verify` is exercised once in the
+    dry-run checklist.
+- **Local dev**: `mise run sbom:rust` after `pnpm -F packages/node run ci-build`; `mise run
+  sbom:js` after `build:ts`.
 - **node-addon-slsa**: unchanged.
 
 ## Consumer scenarios
@@ -305,46 +274,33 @@ gh attestation verify <artifact> --owner vadimpiven \
 
 ## Implementation order
 
-Sections 1–11 are written in commit order:
+Sections 1–11 are in commit order. §5 must land before §6–§10 (which reference its tasks);
+otherwise sections are independent and can be split into per-commit PRs as preferred.
 
-- §1 + §2 (mise pins + Dockerfile bake) land first — subsequent CI changes assume the tools are
-  installed.
-- §3 (cargo-auditable in build:cargo) lands next — one-line edit that later sections depend on.
-- §4 (ship lockfile) is independent of §3 but small — bundle either way.
-- §5 (mise tasks) defines the building blocks. Must land before §6–§10 which reference them.
-- §6 + §7 + §8 extend `build-addon` (verify, Rust SBOM gen, Rust attest).
-- §9 + §10 extend `build-packages` (JS SBOM gen, JS attest).
-- §11 (README) lands last.
-
-After each set of CI changes, `mise run check` must pass (gate enforced by the Stop hook per
-`CLAUDE.md`). To validate the actual workflow, push a release-candidate tag (e.g. `v0.0.0-rc1`) —
-`release.yaml` triggers on `push: tags: v*` and the "Verify tag is on main" check
-(release.yaml:31-39) accepts any tag pointing at a `main` commit.
+After each commit, `mise run check` must pass (Stop hook per `CLAUDE.md`). To validate the
+workflow itself, push a release-candidate tag (`v0.0.0-rc1`) — `release.yaml` triggers on
+`push: tags: v*` and accepts any tag pointing at a `main` commit (release.yaml:31-39).
 
 ## Dry-run checklist
 
-Before the first real `v*` release tag, push a release-candidate tag and verify:
+Push `v0.0.0-rc1` and verify:
 
-1. `build-addon` produces `.dep-v0` in the binary across all matrix targets (Linux x64/arm64
-   manylinux, macOS x64/arm64, Windows x64/arm64).
-2. `mise run sbom:verify` (§6) succeeds on the signed+notarized binary — confirms signing
-   preserves `.dep-v0`.
-3. `mise run sbom:rust` (§7) emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
+1. `.dep-v0` present in the binary across all 6 matrix targets (Linux x64/arm64 manylinux,
+   macOS x64/arm64, Windows x64/arm64).
+2. `mise run sbom:verify` succeeds on the signed+notarized binary — signing didn't strip
+   `.dep-v0`.
+3. `mise run sbom:rust` emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
 4. `actions/attest-sbom` attestations appear in the public transparency log.
-5. `mise run sbom:js` output (§9) contains transitive deps — look for resolved versions of
-   indirect entries (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` was
-   bundled.
+5. `mise run sbom:js` output contains transitive deps — find resolved versions of indirect
+   entries (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` shipped.
 6. `gh attestation verify <artifact> --owner vadimpiven --predicate-type https://cyclonedx.org/bom
-   --format json` succeeds for at least one `.node.gz` and the `package.tar.gz` — confirms the
-   consumer-facing retrieval path works end-to-end. (One-time design check, not a per-release CI
-   job — `actions/attest-sbom` succeeding in the workflow already guarantees the attestation is
-   in Sigstore.)
-7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — confirms
-   consumers can audit independently.
+   --format json` succeeds for one `.node.gz` and the `package.tar.gz` — proves the consumer
+   retrieval path. One-time design check; `actions/attest-sbom` already guarantees Sigstore
+   inclusion per run.
+7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — proves the
+   independent-audit path.
 
-If anything fails: `gh release delete v0.0.0-rc1 --cleanup-tag --yes` and iterate.
+Rollback: `gh release delete v0.0.0-rc1 --cleanup-tag --yes`.
 
-## Notes
-
-- **Dependency updates**: Syft and cargo-auditable pinned in `mise.toml` are picked up by the
-  existing scheduled dependency update workflow. No Renovate config changes needed.
+Syft and cargo-auditable pinned in `mise.toml` are picked up by the existing scheduled dependency
+update workflow — no Renovate config changes.

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -2,370 +2,396 @@
 
 [cyclonedx]: https://cyclonedx.org/
 [gh-attest]: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations
-[cargo-sbom-tracking]: https://github.com/rust-lang/cargo/issues/16565
 
 ## Goal
 
-Audit both Rust and JS dependency trees of the published
-npm package through four complementary mechanisms.
+Ship a target-exact CycloneDX 1.6 SBOM with every release artifact, attested through the GitHub
+Attestations API. Rust SBOMs come from the `.dep-v0` section that `cargo-auditable` embeds at link
+time; the JS SBOM comes from `pnpm-lock.yaml` shipped inside the npm tarball. One generator (Syft)
+covers both.
 
-## Problem
+## Publish topology
 
-The compiled `.node` binary is opaque to JS-level SBOM
-scanners (Trivy, Grype, Syft). The ~100 Rust crates from
-`Cargo.lock` are invisible to consumers. JS dependencies
-bundled into the tarball lack a machine-readable SBOM —
-`pnpm-lock.yaml` is not included in the published package.
+`release.yaml` produces two artifact streams:
+
+- **Per-target `.node.gz`** → `gh release upload` from `build-addon` (one per matrix entry).
+  Contains the compiled Rust binary.
+- **`package.tar.gz`** → `npm publish` from `publish`. JS only (loader, types, `export_dist/`).
+  The `slsa` postinstall fetches the matching `.node.gz` from the GitHub Release.
+
+Rust and JS live in different artifacts, so each gets its own SBOM attested to its own subject.
+Per-target Rust attribution is preserved by construction; no merging required.
 
 ## Scope
 
-| Layer | Tool | Covers | Format |
-| --- | --- | --- | --- |
-| Rust deps (file) | `cargo-cyclonedx` | Cargo.lock tree | CycloneDX 1.5 |
-| Rust deps (embedded) | `cargo-auditable` | Cargo.lock tree | `.dep-v0` section |
-| Cargo build manifest | `-Z sbom` | deps + features + rustc | cargo JSON |
-| JS/TS deps | `rollup-plugin-sbom` | bundled npm deps | CycloneDX 1.6 |
+| Artifact                 | Source of truth                     | Generator | Format        |
+| ------------------------ | ----------------------------------- | --------- | ------------- |
+| `*.node.gz` (per target) | `.dep-v0` section (cargo-auditable) | Syft      | CycloneDX 1.6 |
+| `package.tar.gz` (JS)    | `pnpm-lock.yaml` (shipped)          | Syft      | CycloneDX 1.6 |
 
-**Not covered**: system libraries (none — rustls
-eliminates OpenSSL), build toolchain (rustc, neon-build).
-
-## Format: CycloneDX
-
-CycloneDX over SPDX: both `cargo-cyclonedx` and
-`rollup-plugin-sbom` generate it natively,
-`actions/attest-sbom` accepts it, dominant format in the
-npm/GitHub ecosystem.
-
-Rust SBOM: spec 1.5 (`cargo-cyclonedx` 0.5.7 max).
-JS SBOM: spec 1.6 (`rollup-plugin-sbom` default).
-Consumer tools (Trivy, Grype, Dependency-Track) support
-both.
+Not covered: system libraries (none — rustls eliminates OpenSSL), build toolchain (rustc,
+neon-build).
 
 ## Trust model
 
-SBOM attestations are **as trustworthy as the CI
-environment**. `cargo-cyclonedx` reads `Cargo.lock`
-metadata, `rollup-plugin-sbom` reads the Vite bundle
-graph — neither inspects the compiled binary. Consistent
-with SLSA Level 2-3 guarantees.
+The attestation proves *this SBOM was produced in the same workflow that built the artifact*.
+Combined with `.dep-v0`, it strengthens to *the SBOM reflects what the compiler embedded into the
+binary at link time*. Tampering with the binary post-link breaks `cargo audit bin`; tampering with
+the SBOM breaks attestation verification.
 
-The attestation proves: "this SBOM was produced in the
-same workflow that built the artifact." Not: "the artifact
-contains exactly these dependencies."
+A Cargo.lock-only SBOM would be approximate — `[target.'cfg(...)']` deps and feature flags differ
+per platform (rustls vs schannel vs Security.framework). `.dep-v0` is target-exact because each
+binary only embeds the deps the linker actually consumed.
 
 ## Changes
 
-### 1. Install cargo-cyclonedx via mise
+### 1. Install Syft via mise
 
 ```toml
-# mise.toml
-[tools."github:CycloneDX/cyclonedx-rust-cargo"]
-version_prefix = "cargo-cyclonedx-"
-version = "0.5.7"
-os = ["linux", "macos"]
-[tools."github:CycloneDX/cyclonedx-rust-cargo".platforms]
-linux-x64 = {
-  asset_pattern = "*-x86_64-unknown-linux-musl*"
-}
-macos-x64 = {
-  asset_pattern = "*-x86_64-apple-darwin*"
-}
-macos-arm64 = {
-  asset_pattern = "*-aarch64-apple-darwin*"
-}
+# mise.toml — add inline alongside existing aqua: pins (mise.toml:43-52)
+"aqua:anchore/syft" = "1.44.0"  # latest stable 2026-05-01
 ```
 
-Linux uses the musl binary (statically linked). No
-`aarch64-unknown-linux-*` binary exists, but SBOM
-generation runs only on `ubuntu-latest` (x86_64) in
-`build-packages`.
+Pinned directly (not `anchore/sbom-action`, which lags Syft by 1–2 minor versions). Syft ≥ 1.15
+enables `cargo-auditable-binary-cataloger` by default; ≥ 1.8 emits CycloneDX 1.6 by default.
 
-### 2. Install cargo-auditable via mise (cargo backend)
+### 2. Install cargo-auditable via mise
 
 ```toml
 # mise.toml — add under [tools]
 "cargo:cargo-auditable" = "0.7.4"
 ```
 
-The `cargo:` backend tries `cargo binstall` first, then
-falls back to `cargo install`. `cargo-binstall` is already
-in `mise.toml` (line 53).
+`cargo:` backend tries `cargo binstall` first (already pinned at `mise.toml:53`), falls back to
+source build. The fallback path is load-bearing on linux-arm64: only published arm64 Linux binary
+is glibc 2.39, our manylinux_2_28 base has glibc 2.28 — binstall fails, source build wins.
 
-Handles the linux-arm64 glibc mismatch: the only published
-arm64 Linux binary is GNU, linked against glibc 2.39
-(ubuntu-24.04). The Docker image (`manylinux_2_28`) has
-glibc 2.28 — `binstall` fails, mise falls back to source
-build automatically.
-
-### 3. Add rollup-plugin-sbom to packages/node
-
-```yaml
-# pnpm-workspace.yaml — add to catalog
-rollup-plugin-sbom: 3.0.5
-```
-
-```typescript
-// packages/node/vite.config.mts — add import
-import sbom from "rollup-plugin-sbom";
-
-// add to plugins array, before dts()
-sbom({
-  rootComponentType: "library",
-  generateSerial: true,
-}),
-```
-
-Generates `export_dist/cyclonedx/bom.json` and
-`export_dist/.well-known/sbom` during `vite build`.
-Same pattern as
-`node-addon-slsa/package/vite.config.mts:47-50`.
-
-### 4. Use cargo-auditable for release builds
+### 3. Compile release builds with cargo-auditable
 
 ```jsonc
-// packages/node/package.json
-// before
-"ci-build": "pnpm run build:cargo -r --locked && pnpm run build:ts",
-// after
-"ci-build": "cargo auditable build -r --locked && pnpm run build:ts",
+// packages/node/package.json — patch ci-build (currently line 64)
+"build:cargo": "cargo build",
+"build:cargo:release": "cargo auditable build -r --locked",
+"ci-build": "pnpm run build:cargo:release && pnpm run build:ts",
 ```
 
-Transparent wrapper around `cargo build` that embeds a
-compressed dependency snapshot into the binary's `.dep-v0`
-section. Dev builds stay with plain `cargo build`
-(`build:cargo` unchanged). The release workflow already
-calls `ci-build` (`release.yaml` > `build-addon`).
+`build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release.yaml:86); cargo-auditable
+runs wherever that runs (host on macOS/Windows, manylinux Docker on Linux). Dev `pnpm run build`
+stays on plain `cargo build` — no auditable overhead for non-release work. PE binaries on Windows
+get `.dep-v0` in a PE section, same mechanism as ELF/Mach-O.
 
-### 5. Enable cargo `-Z sbom`
+### 4. Verify auditable metadata in build-addon
 
-```toml
-# .cargo/config.toml — add to existing [build] section
-sbom = true
-
-# add new section
-[unstable]
-sbom = true
-```
-
-Generates `node_reqwest.cargo-sbom.json` alongside the
-`.node` binary during every build — full dependency graph
-with package IDs, features, and rustc version. Unstable
-feature on nightly (`nightly-2026-02-28`). Tracking issue:
-[rust-lang/cargo#16565][cargo-sbom-tracking] — 3 open
-stabilization blockers.
-
-[TODO: verify the exact output path — confirm the file
-ends up in `packages/node/dist/` after the build.]
-
-### 6. Verify auditable metadata in CI
-
-In `release.yaml` > `build-addon`, after "Build node
-addon", before "Sign and notarize":
+New step in `release.yaml > build-addon`, between "Sign and notarize" (release.yaml:87) and "Pack
+node addon" (release.yaml:91). Placement matters: running after sign+notarize verifies signing did
+not strip `.dep-v0`.
 
 ```yaml
 - name: "Verify auditable metadata"
   uses: "./.github/actions/shell"
   with:
-      docker-service: >-
-          ${{ needs.init.outputs.docker-service }}
-      run: |
-          cargo auditable info \
-            packages/node/dist/node_reqwest.node
+    docker-service: ${{ needs.init.outputs.docker-service }}
+    run: |
+      cargo auditable info packages/node/dist/node_reqwest.node
 ```
 
-Exits non-zero if `.dep-v0` is missing, failing the
-release.
+Exits non-zero if `.dep-v0` is missing — fails the release rather than shipping an SBOM-blind
+binary.
 
-### 7. Generate Rust CycloneDX SBOM in `build-packages`
+### 5. Generate per-target Rust SBOM in build-addon
 
-In `build-packages`, after "Build and pack node package",
-before "Attest node build provenance". Runs once on
-`ubuntu-latest` (x86_64) — Rust SBOM is identical across
-platforms (same `Cargo.lock`).
+New steps after "Pack node addon", before "Attest build provenance" (release.yaml:96). Each
+matrix entry produces exactly one `.node.gz` named
+`dist/node_reqwest-v{version}-{platform}-{arch}.node.gz`.
 
 ```yaml
 - name: "Generate Rust SBOM"
   shell: "bash"
   run: |
-    cargo cyclonedx \
-      --manifest-path packages/node/Cargo.toml \
-      --format json \
-      --spec-version 1.5 \
-      --describe crate
-    mv packages/node/bom.json \
-      "packages/node/node_reqwest-${GITHUB_REF_NAME}-rust.cdx.json"
+    mkdir -p packages/node/dist/sbom
+    f=(packages/node/dist/*.node.gz)
+    base="$(basename "${f[0]}" .node.gz)"
+    syft scan "file:${f[0]}" \
+      --override-default-catalogers cargo-auditable-binary-cataloger \
+      -o cyclonedx-json="packages/node/dist/sbom/${base}.cdx.json"
 - name: "Validate Rust SBOM"
   shell: "bash"
   run: |
-    jq -e '.components | length > 50' \
-      packages/node/node_reqwest-*-rust.cdx.json
+    sbom=(packages/node/dist/sbom/*.cdx.json)
+    jq -e '.bomFormat == "CycloneDX"' "${sbom[0]}"
+    # Catches the empty-SBOM failure mode if Syft's default cataloger selection
+    # changes upstream and deselects cargo-auditable silently.
+    jq -e '
+      [.components[]?
+        | select(.properties[]?.value
+          == "cargo-auditable-binary-cataloger")
+      ] | length > 50
+    ' "${sbom[0]}"
 ```
 
-`--describe crate` scopes to the `node` crate's dependency
-tree (including transitive workspace deps `core` and
-`meta`). Validation ensures ~100 expected components are
-present. Uses `shell: "bash"` (host, not Docker), same as
-the existing `attest-build-provenance` step.
+Runs on host shell, not Docker — Syft is verification-only; mise installs it on the runner. `syft
+scan file:...` auto-extracts the `.gz`. Explicit cataloger override defends against
+anchore/syft#2031 (default selection occasionally deselects binary catalogers). Works identically
+for Mach-O, ELF, and PE.
 
-### 8. Rename JS SBOM
+### 6. Attest Rust SBOM in build-addon
 
-Generated by `rollup-plugin-sbom` during `vite build`
-(part of `build:ts`):
-
-```yaml
-- name: "Rename JS SBOM"
-  shell: "bash"
-  run: |
-    mv packages/node/export_dist/cyclonedx/bom.json \
-      "packages/node/node_reqwest-${GITHUB_REF_NAME}-js.cdx.json"
-```
-
-### 9. Attest both SBOMs
-
-After the existing "Attest node build provenance" step:
+New step after "Attest build provenance":
 
 ```yaml
 - name: "Attest Rust SBOM"
-  uses: "actions/attest-sbom@10926c72720ffc3f7b666661c8e55b1344e2a365" # v2.4.0
+  uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
-    subject-path: "packages/node/package.tar.gz"
-    sbom-path: "packages/node/node_reqwest-*-rust.cdx.json"
+    subject-path: "packages/node/dist/*.node.gz"
+    sbom-path: "packages/node/dist/sbom/*.cdx.json"
+```
+
+`actions/attest-sbom` loads one SBOM as predicate and attaches it to all matched subjects (no
+stem-pairing). Per-matrix-entry, both globs resolve to a single file — single-subject,
+single-predicate, no ambiguity.
+
+### 7. Upload Rust SBOMs to GitHub Release
+
+Extend the existing "Upload node addon" step in `build-addon`:
+
+```yaml
+- name: "Upload node addon"
+  shell: "bash"
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    gh release upload "$GITHUB_REF_NAME" \
+      packages/node/dist/*.gz \
+      packages/node/dist/sbom/*.cdx.json
+```
+
+### 8. Generate JS SBOM in build-packages
+
+Ship the lockfile inside the tarball so Syft's pnpm cataloger sees the full resolved tree (without
+it, only direct deps from `package.json` appear). `pnpm pack` resolves `files` relative to the
+package directory — so copy the root lockfile in before pack:
+
+```jsonc
+// packages/node/package.json
+"files": [
+  "export/**/*",
+  "export_dist/**/*",
+  "pnpm-lock.yaml"
+],
+"build:ts": "vite build && typedoc && cp ../../pnpm-lock.yaml . && pnpm pack --out package.tar.gz"
+```
+
+Add `packages/node/pnpm-lock.yaml` to `.gitignore` (transient copy; source of truth stays at repo
+root).
+
+New steps in `release.yaml > build-packages`, after "Build and pack node package", before "Attest
+node build provenance":
+
+```yaml
+- name: "Generate JS SBOM"
+  shell: "bash"
+  run: |
+    syft scan "file:packages/node/package.tar.gz" \
+      -o cyclonedx-json="packages/node/node_reqwest-${GITHUB_REF_NAME}-js.cdx.json"
+- name: "Validate JS SBOM"
+  shell: "bash"
+  run: |
+    jq -e '.bomFormat == "CycloneDX"' \
+      packages/node/node_reqwest-*-js.cdx.json
+    jq -e '
+      [.components[]? | select(.type == "library")] | length > 0
+    ' packages/node/node_reqwest-*-js.cdx.json
+```
+
+### 9. Attest and upload JS SBOM
+
+New step after "Attest node build provenance":
+
+```yaml
 - name: "Attest JS SBOM"
-  uses: "actions/attest-sbom@10926c72720ffc3f7b666661c8e55b1344e2a365" # v2.4.0
+  uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4.1.0
   with:
     subject-path: "packages/node/package.tar.gz"
     sbom-path: "packages/node/node_reqwest-*-js.cdx.json"
 ```
 
-Binds both SBOMs to the npm tarball. `build-packages`
-already has `id-token: write` and `attestations: write`.
-
-[TODO: verify `actions/attest-sbom` supports glob patterns
-in `sbom-path`. If not, use the explicit versioned
-filename.]
-
-### 10. Upload all artifacts to GitHub Release
-
-```yaml
-- name: "Finalize release"
-  uses: "softprops/action-gh-release@..."
-  with:
-    files: |
-      packages/node/package.tar.gz
-      packages/node/node_reqwest-*-rust.cdx.json
-      packages/node/node_reqwest-*-js.cdx.json
-      packages/node/dist/*.cargo-sbom.json
-    draft: false
-```
-
-### 11. Add smoke test verification
-
-In `smoke-test`, after the existing install check:
+Extend the existing upload step:
 
 ```bash
-# Verify SBOMs are downloadable from release
-gh release download "$GITHUB_REF_NAME" \
-  --repo vadimpiven/node_reqwest \
-  --pattern "*.cdx.json"
-# Validate SBOM content
-jq -e '.bomFormat == "CycloneDX"' *-rust.cdx.json
-jq -e '.components | length > 50' *-rust.cdx.json
-jq -e '.bomFormat == "CycloneDX"' *-js.cdx.json
-# Verify SBOM attestation exists
-gh attestation verify \
-  "package.tar.gz" \
-  --owner vadimpiven \
-  --predicate-type https://cyclonedx.org/bom
+gh release upload "$GITHUB_REF_NAME" \
+  packages/node/package.tar.gz \
+  packages/node/node_reqwest-*-js.cdx.json
+gh release edit "$GITHUB_REF_NAME" --draft=false
 ```
 
-[TODO: `smoke-test` has `contents: read` permission.
-`gh attestation verify` may need more — verify.]
+### 10. New job: smoke-sbom
 
-### 12. Add local mise task
+Add a top-level job under `jobs:` in `release.yaml`, alongside the existing `smoke-test`
+(release.yaml:203). Single-runner since SBOM/attestation verification doesn't depend on OS.
+
+```yaml
+smoke-sbom:
+  name: "Smoke test SBOM"
+  timeout-minutes: 5
+  permissions:
+    contents: "read"
+  needs:
+    - "publish"
+  if: needs.publish.result == 'success'
+  runs-on: "ubuntu-latest"
+  steps:
+    - name: "Install syft"
+      # gh is preinstalled on ubuntu-latest
+      shell: "bash"
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+          | sh -s -- -b /usr/local/bin v1.44.0
+    - name: "Download release artifacts"
+      shell: "bash"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        mkdir -p sbom-check && cd sbom-check
+        gh release download "$GITHUB_REF_NAME" \
+          --repo vadimpiven/node_reqwest \
+          --pattern "*.cdx.json" \
+          --pattern "*.node.gz" \
+          --pattern "package.tar.gz"
+    - name: "Validate SBOM content"
+      shell: "bash"
+      run: |
+        cd sbom-check
+        for sbom in *.cdx.json; do
+          jq -e '.bomFormat == "CycloneDX"' "$sbom"
+          jq -e '.specVersion | startswith("1.")' "$sbom"
+        done
+    - name: "Verify attestations"
+      shell: "bash"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd sbom-check
+        for artifact in *.node.gz package.tar.gz; do
+          gh attestation verify "$artifact" \
+            --owner vadimpiven \
+            --predicate-type https://cyclonedx.org/bom
+        done
+```
+
+`gh attestation verify` reads the public transparency log; default `contents: read` is sufficient.
+`GITHUB_TOKEN` env is for rate limits only.
+
+### 11. Add local mise task
 
 ```toml
-# mise.toml
+# mise.toml — workspace target dir is at repo root (./target/)
 [tasks.sbom]
-description = "Generate CycloneDX SBOM for node package"
+description = "Generate CycloneDX SBOM for node package (release build)"
 depends = ["setup:rust"]
 run = """
-cargo cyclonedx \
-  --manifest-path packages/node/Cargo.toml \
-  --format json \
-  --spec-version 1.5 \
-  --describe crate
-echo "SBOM written to packages/node/bom.json"
-jq -e '.components | length' packages/node/bom.json
+cargo auditable build -r --locked -p node
+bin=""
+for candidate in target/release/libnode_reqwest.so \
+                 target/release/libnode_reqwest.dylib \
+                 target/release/node_reqwest.dll; do
+  [ -f "$candidate" ] && bin="$candidate" && break
+done
+[ -n "$bin" ] || { echo "no built artifact found"; exit 1; }
+syft scan "file:$bin" \
+  --override-default-catalogers cargo-auditable-binary-cataloger \
+  -o cyclonedx-json=bom.json
+jq -e '.components | length' bom.json
 """
 sources = ["Cargo.lock", "packages/*/Cargo.toml"]
 ```
 
-### 13. Update README
+Add `/bom.json` to `.gitignore`.
 
-In `packages/node/README.md` > "Installation safety",
-after existing provenance text:
+### 12. Update README
 
-> A [CycloneDX][cyclonedx] SBOM listing all Rust and
-> JavaScript dependencies is attached to each GitHub
-> Release and verifiable via the
-> [GitHub Attestations API][gh-attest].
+In `packages/node/README.md` > "Installation safety", after existing provenance text:
 
-### 14. Scope of impact
+> A [CycloneDX][cyclonedx] SBOM is attached to each GitHub Release: per-target Rust SBOMs (derived
+> from the `cargo-auditable` `.dep-v0` section embedded in each `.node.gz` binary) and a JS SBOM
+> for the npm tarball. Both are verifiable via the [GitHub Attestations API][gh-attest]:
+>
+> ```bash
+> gh attestation verify <artifact> --owner vadimpiven \
+>   --predicate-type https://cyclonedx.org/bom
+> ```
 
-- **Regular CI** (`regular.yaml`): `-Z sbom` generates
-  manifest during builds. No other changes.
-- **Release CI** (`release.yaml`):
-  - `build-addon`: `cargo auditable build` +
-    verification step.
-  - `build-packages`: Rust/JS CycloneDX generation,
-    attestation, upload.
-  - `smoke-test`: SBOM download and validation.
-- **Local dev**: `cargo build` (no auditable), `-Z sbom`
-  generates manifest, `mise run sbom` for CycloneDX.
-- **node-addon-slsa**: Unchanged.
+## Scope of impact
+
+- **`regular.yaml`**: unchanged. Dev builds stay on plain `cargo build`.
+- **`release.yaml`**:
+  - `build-addon`: `cargo auditable build`, verify metadata, per-target Syft SBOM, attestation,
+    upload (§3–7).
+  - `build-packages`: lockfile-bundled tarball, Syft scan, JS SBOM attestation, upload (§8–9).
+  - `smoke-sbom` (new): single-runner SBOM/attestation verification (§10).
+  - `smoke-test`: unchanged.
+- **Local dev**: `mise run sbom` produces a host-target CycloneDX SBOM (§11).
+- **node-addon-slsa**: unchanged.
 
 ## Consumer scenarios
 
-### Automated SBOM ingestion
+### Verify any release artifact
 
 ```bash
 gh attestation verify \
-  node_modules/node-reqwest/dist/node_reqwest.node \
+  node_reqwest-v1.2.3-linux-x64.node.gz \
   --owner vadimpiven \
-  --format json \
   --predicate-type https://cyclonedx.org/bom
 ```
 
-### Binary audit (no API needed)
+### Audit the binary you installed
 
 ```bash
-cargo audit bin \
-  node_modules/node-reqwest/dist/node_reqwest.node
+# Reads .dep-v0 directly — no network, no API.
+cargo audit bin node_modules/node-reqwest/dist/node_reqwest.node
 ```
 
-### Manual download
+### Bulk CVE response
 
-```bash
-gh release download v1.2.3 \
-  --repo vadimpiven/node_reqwest \
-  --pattern "*.cdx.json"
-```
+CVE drops for `rustls@0.23.x`. Security team downloads per-target SBOMs from the release, greps
+the affected crate, identifies impacted installations — target-exact, no false positives from
+features compiled out on their platform.
 
-### CVE response
+## Implementation order
 
-A CVE drops for `rustls@0.23.x`. The security team
-searches aggregated SBOMs, finds `rustls@0.23.25` in the
-Rust SBOM, identifies affected applications — without
-contacting the maintainer.
+Sections 1–12 are written in commit order:
 
-## Remaining TODOs
+- §1 + §2 (mise pins) land first — subsequent CI changes assume the tools are installed.
+- §3 + §4 are tightly coupled (auditable build + verify) — land together.
+- §5–§7 extend `build-addon` (Rust SBOM gen, attest, upload).
+- §8–§9 extend `build-packages` (JS SBOM gen, attest, upload).
+- §10 adds the verification job.
+- §11 is local-dev convenience — lands anytime.
+- §12 (README) lands last.
 
-1. Verify `cargo-cyclonedx` is available on
-   `ubuntu-latest` after `mise install` with
-   `os = ["linux", "macos"]`.
-2. Verify `gh attestation verify` works in smoke test
-   with only `contents: read` permission.
-3. Verify `actions/attest-sbom` supports glob patterns
-   in `sbom-path`.
-4. Verify `cargo -Z sbom` output path ends up in
-   `packages/node/dist/` after the build.
+After each set of CI changes, `mise run check` must pass (gate enforced by the Stop hook per
+`CLAUDE.md`). To validate the actual workflow, push a release-candidate tag (e.g. `v0.0.0-rc1`) —
+`release.yaml` triggers on `push: tags: v*` and the "Verify tag is on main" check
+(release.yaml:31-39) accepts any tag pointing at a `main` commit.
+
+## Dry-run checklist
+
+Before the first real `v*` release tag, push a release-candidate tag and verify:
+
+1. `build-addon` produces `.dep-v0` in the binary across all matrix targets (Linux x64/arm64
+   manylinux, macOS x64/arm64, Windows x64/arm64).
+2. `cargo auditable info` (§4) succeeds on the signed+notarized binary — confirms signing
+   preserves `.dep-v0`.
+3. Syft (§5) emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
+4. `actions/attest-sbom` attestations appear in the public transparency log.
+5. JS SBOM (§8) contains transitive deps — look for resolved versions of indirect entries
+   (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` was bundled.
+6. `smoke-sbom` (§10) passes end-to-end.
+7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — confirms
+   consumers can audit independently.
+
+If anything fails: `gh release delete v0.0.0-rc1 --cleanup-tag --yes` and iterate.
+
+## Notes
+
+- **Dependency updates**: Syft and cargo-auditable pinned in `mise.toml` are picked up by the
+  existing scheduled dependency update workflow. No Renovate config changes needed.

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -184,22 +184,7 @@ New step after "Attest build provenance":
 stem-pairing). Per-matrix-entry, both globs resolve to a single file — single-subject,
 single-predicate, no ambiguity.
 
-### 7. Upload Rust SBOMs to GitHub Release
-
-Extend the existing "Upload node addon" step in `build-addon`:
-
-```yaml
-- name: "Upload node addon"
-  shell: "bash"
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  run: |
-    gh release upload "$GITHUB_REF_NAME" \
-      packages/node/dist/*.gz \
-      packages/node/dist/sbom/*.cdx.json
-```
-
-### 8. Generate JS SBOM in build-packages
+### 7. Generate JS SBOM in build-packages
 
 Ship the lockfile inside the tarball so Syft's pnpm cataloger sees the full resolved tree (without
 it, only direct deps from `package.json` appear). `pnpm pack` resolves `files` relative to the
@@ -237,7 +222,7 @@ node build provenance":
     ' packages/node/node_reqwest-*-js.cdx.json
 ```
 
-### 9. Attest and upload JS SBOM
+### 8. Attest JS SBOM
 
 New step after "Attest node build provenance":
 
@@ -249,16 +234,10 @@ New step after "Attest node build provenance":
     sbom-path: "packages/node/node_reqwest-*-js.cdx.json"
 ```
 
-Extend the existing upload step:
+Existing upload step in `build-packages` (release.yaml:155-160) is unchanged — SBOMs live in the
+attestation predicate, not as separate release assets.
 
-```bash
-gh release upload "$GITHUB_REF_NAME" \
-  packages/node/package.tar.gz \
-  packages/node/node_reqwest-*-js.cdx.json
-gh release edit "$GITHUB_REF_NAME" --draft=false
-```
-
-### 10. New job: smoke-sbom
+### 9. New job: smoke-sbom
 
 Add a top-level job under `jobs:` in `release.yaml`, alongside the existing `smoke-test`
 (release.yaml:203). Single-runner since SBOM/attestation verification doesn't depend on OS.
@@ -274,12 +253,6 @@ smoke-sbom:
   if: needs.publish.result == 'success'
   runs-on: "ubuntu-latest"
   steps:
-    - name: "Install syft"
-      # gh is preinstalled on ubuntu-latest
-      shell: "bash"
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-          | sh -s -- -b /usr/local/bin v1.44.0
     - name: "Download release artifacts"
       shell: "bash"
       env:
@@ -288,34 +261,33 @@ smoke-sbom:
         mkdir -p sbom-check && cd sbom-check
         gh release download "$GITHUB_REF_NAME" \
           --repo vadimpiven/node_reqwest \
-          --pattern "*.cdx.json" \
           --pattern "*.node.gz" \
           --pattern "package.tar.gz"
-    - name: "Validate SBOM content"
-      shell: "bash"
-      run: |
-        cd sbom-check
-        for sbom in *.cdx.json; do
-          jq -e '.bomFormat == "CycloneDX"' "$sbom"
-          jq -e '.specVersion | startswith("1.")' "$sbom"
-        done
-    - name: "Verify attestations"
+    - name: "Verify attestation + extract SBOM"
       shell: "bash"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd sbom-check
         for artifact in *.node.gz package.tar.gz; do
+          # Verifies signature + transparency log inclusion, returns the
+          # attestation bundle (which embeds the SBOM as its predicate).
           gh attestation verify "$artifact" \
             --owner vadimpiven \
-            --predicate-type https://cyclonedx.org/bom
+            --predicate-type https://cyclonedx.org/bom \
+            --format json > "${artifact}.attestation.json"
+          # Extract the SBOM predicate and validate its shape.
+          jq -e '.[0].verificationResult.statement.predicate.bomFormat == "CycloneDX"' \
+            "${artifact}.attestation.json"
         done
 ```
 
 `gh attestation verify` reads the public transparency log; default `contents: read` is sufficient.
-`GITHUB_TOKEN` env is for rate limits only.
+`GITHUB_TOKEN` env is for rate limits only. The verify call returns the full attestation bundle
+including the SBOM predicate — no separate SBOM download needed since the SBOM lives in the
+attestation, not as a release asset.
 
-### 11. Add local mise task
+### 10. Add local mise task
 
 ```toml
 # mise.toml — workspace target dir is at repo root (./target/)
@@ -341,17 +313,19 @@ sources = ["Cargo.lock", "packages/*/Cargo.toml"]
 
 Add `/bom.json` to `.gitignore`.
 
-### 12. Update README
+### 11. Update README
 
 In `packages/node/README.md` > "Installation safety", after existing provenance text:
 
-> A [CycloneDX][cyclonedx] SBOM is attached to each GitHub Release: per-target Rust SBOMs (derived
-> from the `cargo-auditable` `.dep-v0` section embedded in each `.node.gz` binary) and a JS SBOM
-> for the npm tarball. Both are verifiable via the [GitHub Attestations API][gh-attest]:
+> A [CycloneDX][cyclonedx] SBOM is attested for every release artifact: per-target Rust SBOMs
+> (derived from the `cargo-auditable` `.dep-v0` section embedded in each `.node.gz` binary) and a
+> JS SBOM for the npm tarball. The SBOM lives inside the attestation predicate, retrievable via
+> the [GitHub Attestations API][gh-attest]:
 >
 > ```bash
 > gh attestation verify <artifact> --owner vadimpiven \
->   --predicate-type https://cyclonedx.org/bom
+>   --predicate-type https://cyclonedx.org/bom \
+>   --format json | jq '.[0].verificationResult.statement.predicate'
 > ```
 
 ## Scope of impact
@@ -359,12 +333,13 @@ In `packages/node/README.md` > "Installation safety", after existing provenance 
 - **`regular.yaml`**: unchanged in workflow logic. All builds (dev + CI) now go through
   `cargo auditable build` via `build:cargo` — negligible overhead, single code path.
 - **`release.yaml`**:
-  - `build-addon`: `cargo auditable build`, verify metadata, per-target Syft SBOM, attestation,
-    upload (§3–7).
-  - `build-packages`: lockfile-bundled tarball, Syft scan, JS SBOM attestation, upload (§8–9).
-  - `smoke-sbom` (new): single-runner SBOM/attestation verification (§10).
+  - `build-addon`: `cargo auditable build`, verify metadata, per-target Syft SBOM, attestation
+    (§3–6). Existing release upload unchanged — SBOMs live in the attestation predicate.
+  - `build-packages`: lockfile-bundled tarball, Syft scan, JS SBOM attestation (§7–8). Existing
+    release upload unchanged.
+  - `smoke-sbom` (new): single-runner attestation verification + SBOM extraction (§9).
   - `smoke-test`: unchanged.
-- **Local dev**: `mise run sbom` produces a host-target CycloneDX SBOM (§11).
+- **Local dev**: `mise run sbom` produces a host-target CycloneDX SBOM (§10).
 - **node-addon-slsa**: unchanged.
 
 ## Consumer scenarios
@@ -387,21 +362,30 @@ cargo audit bin node_modules/node-reqwest/dist/node_reqwest.node
 
 ### Bulk CVE response
 
-CVE drops for `rustls@0.23.x`. Security team downloads per-target SBOMs from the release, greps
-the affected crate, identifies impacted installations — target-exact, no false positives from
-features compiled out on their platform.
+CVE drops for `rustls@0.23.x`. Security team fetches each artifact's attestation, extracts the
+SBOM predicate, greps the affected crate, identifies impacted installations — target-exact, no
+false positives from features compiled out on their platform:
+
+```bash
+gh attestation verify <artifact> --owner vadimpiven \
+  --predicate-type https://cyclonedx.org/bom \
+  --format json \
+  | jq '.[0].verificationResult.statement.predicate.components[]
+        | select(.name == "rustls") | .version'
+```
 
 ## Implementation order
 
-Sections 1–12 are written in commit order:
+Sections 1–11 are written in commit order:
 
-- §1 + §2 (mise pins) land first — subsequent CI changes assume the tools are installed.
+- §1 + §2 (mise pins + Dockerfile bake) land first — subsequent CI changes assume the tools are
+  installed.
 - §3 + §4 are tightly coupled (auditable build + verify) — land together.
-- §5–§7 extend `build-addon` (Rust SBOM gen, attest, upload).
-- §8–§9 extend `build-packages` (JS SBOM gen, attest, upload).
-- §10 adds the verification job.
-- §11 is local-dev convenience — lands anytime.
-- §12 (README) lands last.
+- §5 + §6 extend `build-addon` (Rust SBOM gen, attest).
+- §7 + §8 extend `build-packages` (JS SBOM gen, attest).
+- §9 adds the verification job.
+- §10 is local-dev convenience — lands anytime.
+- §11 (README) lands last.
 
 After each set of CI changes, `mise run check` must pass (gate enforced by the Stop hook per
 `CLAUDE.md`). To validate the actual workflow, push a release-candidate tag (e.g. `v0.0.0-rc1`) —
@@ -418,9 +402,10 @@ Before the first real `v*` release tag, push a release-candidate tag and verify:
    preserves `.dep-v0`.
 3. Syft (§5) emits CycloneDX 1.6 with > 50 cargo-auditable components per target.
 4. `actions/attest-sbom` attestations appear in the public transparency log.
-5. JS SBOM (§8) contains transitive deps — look for resolved versions of indirect entries
+5. JS SBOM (§7) contains transitive deps — look for resolved versions of indirect entries
    (e.g. transitive `undici` or `@types/*`) to confirm `pnpm-lock.yaml` was bundled.
-6. `smoke-sbom` (§10) passes end-to-end.
+6. `smoke-sbom` (§9) passes end-to-end — attestation verifies AND the embedded SBOM predicate
+   is well-formed CycloneDX.
 7. `cargo audit bin` works on a notarized macOS `.node` extracted from `.node.gz` — confirms
    consumers can audit independently.
 

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -110,45 +110,91 @@ root).
 
 All SBOM work lives in `mise.toml`. CI and local dev call the same tasks.
 
+Validation lives in node scripts (matches the existing pattern in `scripts/`, per CLAUDE.md
+> Scripts). mise tasks chain `syft` then `node scripts/<validate>.ts` — every `run` entry is a
+binary call with plain args, portable across cmd.exe, PowerShell, bash, sh.
+
+```typescript
+// scripts/sbom-validate-rust.ts
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import fs from "node:fs";
+import { runScript } from "./helpers/run-script.ts";
+
+const MIN_COMPONENTS = 50;
+
+runScript("Validate Rust SBOM", async () => {
+  const path = "packages/node/dist/node_reqwest.cdx.json";
+  const bom = JSON.parse(fs.readFileSync(path, "utf8")) as {
+    components?: Array<{ properties?: Array<{ value?: string }> }>;
+  };
+  const count = (bom.components ?? []).filter((c) =>
+    c.properties?.some((p) => p.value === "cargo-auditable-binary-cataloger"),
+  ).length;
+  if (count <= MIN_COMPONENTS) {
+    throw new Error(
+      `expected > ${MIN_COMPONENTS} cargo-auditable components in ${path}, got ${count}`,
+    );
+  }
+  console.log(`OK: ${count} cargo-auditable components`);
+});
+```
+
+```typescript
+// scripts/sbom-validate-js.ts
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import fs from "node:fs";
+import { runScript } from "./helpers/run-script.ts";
+
+runScript("Validate JS SBOM", async () => {
+  const path = "packages/node/package.cdx.json";
+  const bom = JSON.parse(fs.readFileSync(path, "utf8")) as {
+    components?: Array<{ type?: string }>;
+  };
+  const count = (bom.components ?? []).filter((c) => c.type === "library").length;
+  if (count === 0) {
+    throw new Error(`expected > 0 library components in ${path}, got 0`);
+  }
+  console.log(`OK: ${count} library components`);
+});
+```
+
 ```toml
-# mise.toml — all three tasks set shell="bash -c" because the jq filters use
-# single-quoted args. mise on Windows defaults to cmd.exe, which doesn't strip
-# single quotes, so the filter would reach jq with stray quotes. git-bash is
-# available on GitHub Actions Windows runners and on any Git-for-Windows dev box.
+# mise.toml — no `shell` override needed; every `run` entry is a binary
+# invocation with plain args, portable across all OS shells.
 
 # Exits non-zero if .dep-v0 missing.
 [tasks."sbom:verify"]
 description = "Check .dep-v0 is present in the built addon"
-shell = "bash -c"
 run = "cargo auditable info packages/node/dist/node_reqwest.node"
 
 [tasks."sbom:rust"]
 description = "Generate CycloneDX SBOM from the addon's .dep-v0 section"
 depends = ["sbom:verify"]
-shell = "bash -c"
 run = [
-  '''syft scan packages/node/dist/node_reqwest.node --override-default-catalogers cargo-auditable-binary-cataloger -o cyclonedx-json=packages/node/dist/node_reqwest.cdx.json''',
-  '''jq -e '.bomFormat == "CycloneDX"' packages/node/dist/node_reqwest.cdx.json''',
-  '''jq -e '[.components[]? | select(.properties[]?.value == "cargo-auditable-binary-cataloger")] | length > 50' packages/node/dist/node_reqwest.cdx.json''',
+  "syft scan packages/node/dist/node_reqwest.node --override-default-catalogers cargo-auditable-binary-cataloger -o cyclonedx-json=packages/node/dist/node_reqwest.cdx.json",
+  "node scripts/sbom-validate-rust.ts",
 ]
 
 [tasks."sbom:js"]
 description = "Generate CycloneDX SBOM from the packed npm tarball"
-shell = "bash -c"
 run = [
-  '''syft scan packages/node/package.tar.gz -o cyclonedx-json=packages/node/package.cdx.json''',
-  '''jq -e '.bomFormat == "CycloneDX"' packages/node/package.cdx.json''',
-  '''jq -e '[.components[]? | select(.type == "library")] | length > 0' packages/node/package.cdx.json''',
+  "syft scan packages/node/package.tar.gz -o cyclonedx-json=packages/node/package.cdx.json",
+  "node scripts/sbom-validate-js.ts",
 ]
 ```
 
 Add `packages/node/dist/node_reqwest.cdx.json` and `packages/node/package.cdx.json` to
-`.gitignore`.
+`.gitignore`. The `bomFormat == "CycloneDX"` check is dropped — Syft's `-o cyclonedx-json` already
+guarantees that field; the validators catch the genuine failure mode (Syft ran but the cataloger
+silently produced zero components).
 
 - **Fixed paths in / out**: each matrix entry writes one SBOM in its own workspace; the attest
   step picks it up by literal name.
 - **No host-target probing**: Syft reads `.dep-v0` from ELF / Mach-O / PE identically.
-- **bash on all platforms**: `shell = "bash -c"` per task — uses git-bash on Windows.
+- **No shell idioms**: every `run` entry is a binary call with plain args. Works on cmd.exe,
+  PowerShell, bash, sh — no `shell = "..."` override, no jq dependency.
 
 ### 6. Wire SBOM steps into `release.yaml`
 

--- a/plans/06-sbom-attestation.md
+++ b/plans/06-sbom-attestation.md
@@ -99,19 +99,20 @@ Single compile per image rebuild, cached in a Docker layer. Subsequent `docker b
 the layer; CI runs see a pre-installed binary. Bump `--version` in lockstep with the mise.toml pin
 when upgrading.
 
-### 3. Compile release builds with cargo-auditable
+### 3. Compile all builds with cargo-auditable
 
 ```jsonc
-// packages/node/package.json — patch ci-build (currently line 64)
-"build:cargo": "cargo build",
-"build:cargo:release": "cargo auditable build -r --locked",
-"ci-build": "pnpm run build:cargo:release && pnpm run build:ts",
+// packages/node/package.json — patch build:cargo (currently line 53)
+"build:cargo": "cargo auditable build",
+// ci-build stays as-is (line 64); -r --locked are forwarded to cargo auditable build:
+"ci-build": "pnpm run build:cargo -r --locked && pnpm run build:ts"
 ```
 
-`build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release.yaml:86); cargo-auditable
-runs wherever that runs (host on macOS/Windows, manylinux Docker on Linux). Dev `pnpm run build`
-stays on plain `cargo build` — no auditable overhead for non-release work. PE binaries on Windows
-get `.dep-v0` in a PE section, same mechanism as ELF/Mach-O.
+cargo-auditable is a thin wrapper that delegates to `cargo build` and embeds a compressed dep
+manifest into a binary section — overhead is negligible, so dev and release builds use the same
+command. `build-addon` invokes `pnpm -F "{packages/node}" run ci-build` (release.yaml:86);
+cargo-auditable runs wherever that runs (host on macOS/Windows, manylinux Docker on Linux). PE
+binaries on Windows get `.dep-v0` in a PE section, same mechanism as ELF/Mach-O.
 
 ### 4. Verify auditable metadata in build-addon
 
@@ -355,7 +356,8 @@ In `packages/node/README.md` > "Installation safety", after existing provenance 
 
 ## Scope of impact
 
-- **`regular.yaml`**: unchanged. Dev builds stay on plain `cargo build`.
+- **`regular.yaml`**: unchanged in workflow logic. All builds (dev + CI) now go through
+  `cargo auditable build` via `build:cargo` — negligible overhead, single code path.
 - **`release.yaml`**:
   - `build-addon`: `cargo auditable build`, verify metadata, per-target Syft SBOM, attestation,
     upload (§3–7).


### PR DESCRIPTION
Rewrites plans/06-sbom-attestation.md to produce target-exact CycloneDX 1.6 SBOMs derived from .dep-v0 (cargo-auditable) for Rust artifacts and from pnpm-lock.yaml for the npm tarball, attested via actions/attest-sbom.

Drops cargo-cyclonedx (Cargo.lock-only, approximate), -Z sbom (unstable nightly, redundant), and rollup-plugin-sbom (bundle-only, misses externals) in favor of a single Syft-based pipeline.