### PR TITLE
test(node): bump playwright timeout to 180s for macOS CI

### DIFF
--- a/packages/node/playwright.config.ts
+++ b/packages/node/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  timeout: 60000,
+  timeout: 180000,
   globalSetup: "./tests/global-setup.ts",
   testDir: "./tests/playwright",
   reporter: [


### PR DESCRIPTION
## Summary

- Bumps the playwright global `timeout` from 60s → 180s in `packages/node/playwright.config.ts`.
- Fixes the recurring `tests/playwright/main.test.ts` flake on macOS runners (failures in runs [26020230497](https://github.com/vadimpiven/node_reqwest/actions/runs/26020230497), [26149543123](https://github.com/vadimpiven/node_reqwest/actions/runs/26149543123), [26213741016](https://github.com/vadimpiven/node_reqwest/actions/runs/26213741016), [26355336902](https://github.com/vadimpiven/node_reqwest/actions/runs/26355336902)).

## Why

`mise run ci-test` fans out `ci-test:core`, `ci-test:meta`, and `ci-test:node` in parallel. On the macOS runners the release-profile Rust build for `nrcore` takes ~2m29s and overlaps the Electron playwright run, starving it of CPU. The timeout fires in `beforeEach`, the test body, or `afterEach` depending on where the scheduler stalls — all symptoms of resource contention rather than a real test regression. 180s gives enough headroom without changing test semantics.

If flakes persist, the next step would be serializing `ci-test:node` after `ci-test:core` in `mise.toml` (trades CI wall-time for stability).

## Test plan

- [ ] CI green on macos-15 and macos-15-intel
- [ ] `mise run -f test` still passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)