### PR TITLE
fix(release): disable pnpm 11 verifyDepsBeforeRun

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,15 +3,15 @@ packages:
   - packages/meta
   - packages/node
 
-# pnpm 11 supersedes the legacy `onlyBuiltDependencies` list with a map of
-# explicit per-package toggles. Anything not listed here is silently skipped
-# (with `strictDepBuilds: true`, blocked outright).
 allowBuilds:
   electron: true
   esbuild: true
   node-addon-slsa: true
 
 blockExoticSubdeps: true
+
+# required for `bump-version` script to not trigger packages reinstall
+verifyDepsBeforeRun: false
 
 catalog:
   "@codecov/vite-plugin": 2.0.1
@@ -39,9 +39,6 @@ catalog:
 
 minimumReleaseAge: 1440
 
-# pnpm 11 stopped honoring the legacy `npm_config_store_dir` env var.
-# Pin the store inside `.cache/native/pnpm` so it stays under the
-# directory that's gitignored and excluded from trivy / coverage scans.
 storeDir: .cache/native/pnpm
 
 minimumReleaseAgeExclude:


### PR DESCRIPTION
pnpm 11 (PR #156) made `verifyDepsBeforeRun: install` the default, which silently re-runs `pnpm install` whenever a workspace manifest hash changes. The release build mutates `packages/node/package.json` via `bump-version` between the initial `mise install` and the build script, so pnpm transparently re-installed and ran the package's `slsa wget` postinstall against a version that has not been published yet (slsa wget skips `0.0.0` but errors on every other un-published version). Linux failed first on the proxied DNS lookup; macOS got further and surfaced the underlying provenance check failure.

Disable the implicit reinstall — `mise run setup:pnpm` already tracks dependency freshness via task `sources`.